### PR TITLE
Use a part object as the layout template's scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.0
-  - rbx-2
+  - rbx
   - jruby-9000
   - ruby-head
   - jruby-head

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 group :test do
   gem 'byebug', platform: :mri
   gem 'slim'
-  gem 'erubis'
 
   gem 'codeclimate-test-reporter', platform: :rbx
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 group :test do
   gem 'byebug', platform: :mri
   gem 'slim'
+  gem 'erubis'
 
   gem 'codeclimate-test-reporter', platform: :rbx
 end

--- a/lib/dry/view/layout.rb
+++ b/lib/dry/view/layout.rb
@@ -12,8 +12,6 @@ module Dry
     class Layout
       include Dry::Equalizer(:config)
 
-      Scope = Struct.new(:page)
-
       DEFAULT_DIR = 'layouts'.freeze
 
       extend Dry::Configurable
@@ -94,7 +92,11 @@ module Dry
       private
 
       def layout_scope(options, renderer)
-        Scope.new(layout_part(:page, renderer, options.fetch(:scope, scope)))
+        part_hash = {
+          page: layout_part(:page, renderer, options.fetch(:scope, scope))
+        }
+
+        part(layout_dir, renderer, part_hash)
       end
 
       def template_scope(options, renderer)

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -1,15 +1,13 @@
 RSpec.describe 'dry-view' do
   let(:view_class) do
-    klass = Class.new(Dry::View::Layout)
-
-    klass.configure do |config|
-      config.root = SPEC_ROOT.join('fixtures/templates')
-      config.name = 'app'
-      config.template = 'users'
-      config.formats = {html: :slim, txt: :erb}
+    Class.new(Dry::View::Layout) do
+      configure do |config|
+        config.root = SPEC_ROOT.join('fixtures/templates')
+        config.name = 'app'
+        config.template = 'users'
+        config.formats = {html: :slim, txt: :erb}
+      end
     end
-
-    klass
   end
 
   let(:scope) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ SPEC_ROOT = Pathname(__FILE__).dirname
 
 require 'dry-view'
 require 'slim'
+require 'erb'
 
 RSpec.configure do |config|
   config.disable_monkey_patching!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,9 +9,9 @@ rescue LoadError; end
 
 SPEC_ROOT = Pathname(__FILE__).dirname
 
-require 'dry-view'
+require 'tilt/erubis'
 require 'slim'
-require 'erb'
+require 'dry-view'
 
 RSpec.configure do |config|
   config.disable_monkey_patching!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,13 @@ rescue LoadError; end
 
 SPEC_ROOT = Pathname(__FILE__).dirname
 
-require 'tilt/erubis'
+require 'erb'
 require 'slim'
+
+# Prefer plain ERB processor rather than erubis (which has problems on JRuby)
+require 'tilt'
+Tilt.register 'erb', Tilt::ERBTemplate
+
 require 'dry-view'
 
 RSpec.configure do |config|


### PR DESCRIPTION
Instead of using a struct with a `page` accessor as the layout's scope, use a Rodakase::View::Part` object like we already do for the non-layout templates.

This allows rendering of partials via `== partial_name` instead of having to chain them onto the page object (i.e. `== page.partial_name`).

The general upshot is that it makes authoring layouts much more consistent with authoring templates by making the same partial rendering behaviour apply everywhere.

<hr>

_Copied from https://github.com/dry-rb/dry-web/pull/19, which was pushed back when dry-view was still a part of Rodakase/dry-web_