### PR TITLE
Fix error: Template file is not valid US-ASCII

### DIFF
--- a/lib/dry/view/renderer.rb
+++ b/lib/dry/view/renderer.rb
@@ -37,7 +37,7 @@ module Dry
       end
 
       def tilt(path)
-        tilts.fetch(path) { tilts[path] = Tilt[engine].new(path) }
+        tilts.fetch(path) { tilts[path] = Tilt[engine].new(path, nil, default_encoding: "utf-8") }
       end
 
       def lookup(name)


### PR DESCRIPTION
Template file is not valid US-ASCII (Encoding::InvalidByteSequenceError) occurred when I try render layout with utf-8 characters on remote server.

Related to: https://github.com/hanami/view/issues/76