### PR TITLE
Support multiple template paths

### DIFF
--- a/lib/dry/view/layout.rb
+++ b/lib/dry/view/layout.rb
@@ -2,6 +2,7 @@ require 'dry-configurable'
 require 'dry-equalizer'
 require 'inflecto'
 
+require 'dry/view/path'
 require 'dry/view/part'
 require 'dry/view/value_part'
 require 'dry/view/null_part'
@@ -16,7 +17,7 @@ module Dry
 
       extend Dry::Configurable
 
-      setting :root
+      setting :paths
       setting :name
       setting :template
       setting :formats, { html: :erb }
@@ -24,6 +25,10 @@ module Dry
 
       attr_reader :config, :scope, :layout_dir, :layout_path, :template_path,
         :default_format
+
+      def self.paths
+        Array(config.paths).map { |path| Dry::View::Path.new(path) }
+      end
 
       def self.renderer(format = default_format)
         unless config.formats.key?(format.to_sym)
@@ -35,9 +40,7 @@ module Dry
 
       def self.renderers
         @renderers ||= Hash.new do |h, key|
-          h[key.to_sym] = Renderer.new(
-            config.root, format: key, engine: config.formats[key.to_sym]
-          )
+          h[key.to_sym] = Renderer.new(paths, format: key, engine: config.formats[key.to_sym])
         end
       end
 

--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -1,0 +1,38 @@
+require "pathname"
+
+module Dry
+  module View
+    class Path
+      include Dry::Equalizer(:dir, :root)
+
+      attr_reader :dir, :root
+
+      def initialize(dir, options = {})
+        @dir = Pathname(dir)
+        @root = Pathname(options.fetch(:root, dir))
+      end
+
+      def lookup(name)
+        template?(name) || template?("shared/#{name}") || !root? && chdir('..').lookup(name)
+      end
+
+      def chdir(dirname)
+        self.class.new(dir.join(dirname), root: root)
+      end
+
+      def to_s
+        dir
+      end
+
+      private
+
+      def root?
+        dir == root
+      end
+
+      def template?(name)
+        dir.join(name) if File.exist?(dir.join(name))
+      end
+    end
+  end
+end

--- a/spec/fixtures/templates_override/users.html.slim
+++ b/spec/fixtures/templates_override/users.html.slim
@@ -1,0 +1,6 @@
+h1 OVERRIDE
+h2 = subtitle
+
+.users
+  == users.index_table do
+    == users.tbody

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'dry-view' do
   let(:view_class) do
     Class.new(Dry::View::Layout) do
       configure do |config|
-        config.root = SPEC_ROOT.join('fixtures/templates')
+        config.paths = SPEC_ROOT.join('fixtures/templates')
         config.name = 'app'
         config.template = 'users'
         config.formats = {html: :slim, txt: :erb}
@@ -40,11 +40,28 @@ RSpec.describe 'dry-view' do
     )
   end
 
+  it 'renders a view with a template on another view path' do
+    view = Class.new(view_class) do
+      configure do |config|
+        config.paths = [SPEC_ROOT.join('fixtures/templates_override')] + Array(config.paths)
+      end
+    end.new
+
+    users = [
+      { name: 'Jane', email: 'jane@doe.org' },
+      { name: 'Joe', email: 'joe@doe.org' }
+    ]
+
+    expect(view.(scope: scope, locals: {subtitle: 'Users List', users: users })).to eq(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h1>OVERRIDE</h1><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    )
+  end
+
   describe 'inheritance' do
     let(:parent_view) do
       klass = Class.new(Dry::View::Layout)
 
-      klass.setting :root, SPEC_ROOT.join('fixtures/templates')
+      klass.setting :paths, SPEC_ROOT.join('fixtures/templates')
       klass.setting :name, 'app'
       klass.setting :formats, {html: :slim}
 

--- a/spec/unit/layout_spec.rb
+++ b/spec/unit/layout_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Dry::View::Layout do
     klass = Class.new(Dry::View::Layout)
 
     klass.configure do |config|
-      config.root = SPEC_ROOT.join('fixtures/templates')
+      config.paths = SPEC_ROOT.join('fixtures/templates')
       config.name = 'app'
       config.template = 'user'
       config.formats = {html: :slim}

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -1,8 +1,9 @@
+require 'dry/view/path'
 require 'dry/view/renderer'
 
 RSpec.describe Dry::View::Renderer do
   subject(:renderer) do
-    Dry::View::Renderer.new(SPEC_ROOT.join('fixtures/templates'), format: 'html', engine: :slim)
+    Dry::View::Renderer.new([Dry::View::Path.new(SPEC_ROOT.join('fixtures/templates'))], format: 'html', engine: :slim)
   end
 
   let(:scope) { double(:scope) }


### PR DESCRIPTION
Replace `Dry::View::Layout`'s `root` config with `paths`, which accepts one or more directory paths. Templates will be searched on all of these paths, with the first match being used.

This will make it possible to ship view-oriented gems with bundled templates, as well as some potential for apps to share templates in interesting ways.

Obviously, the more template paths, the more file system checks we have to make in order to locate a template. At some point it'd probably be prudent to add caching of these, but for now, this change will make it possible for us to start shipping some of these view-oriented gems I hinted at above (like one to make pagination easy to handle across apps).

@solnic, what do you reckon?