### PR TITLE
Make arguments to partial method calls available within their templates

### DIFF
--- a/lib/dry/view/null_part.rb
+++ b/lib/dry/view/null_part.rb
@@ -1,5 +1,4 @@
 require 'dry-equalizer'
-require 'dry/view/value_part'
 
 module Dry
   module View
@@ -12,7 +11,7 @@ module Dry
 
       def with(scope)
         if scope.any?
-          ValuePart.new(renderer, _data.merge(scope))
+          self.class.new(renderer, _data.merge(scope))
         else
           self
         end
@@ -28,7 +27,7 @@ module Dry
         template_path = template?("#{meth}_missing")
 
         if template_path
-          render(template_path, *args, &block)
+          render(template_path, prepare_render_scope(meth, *args), &block)
         else
           nil
         end

--- a/lib/dry/view/null_part.rb
+++ b/lib/dry/view/null_part.rb
@@ -11,7 +11,11 @@ module Dry
       end
 
       def with(scope)
-        ValuePart.new(renderer, _data.merge(scope))
+        if scope.any?
+          ValuePart.new(renderer, _data.merge(scope))
+        else
+          self
+        end
       end
 
       def respond_to_missing?(*)

--- a/lib/dry/view/null_part.rb
+++ b/lib/dry/view/null_part.rb
@@ -10,6 +10,10 @@ module Dry
       def each(&block)
       end
 
+      def with(scope)
+        ValuePart.new(renderer, _data.merge(scope))
+      end
+
       def respond_to_missing?(*)
         true
       end
@@ -20,7 +24,7 @@ module Dry
         template_path = template?("#{meth}_missing")
 
         if template_path
-          render(template_path)
+          render(template_path, *args, &block)
         else
           nil
         end

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -11,12 +11,16 @@ module Dry
         @renderer = renderer
       end
 
-      def render(path, &block)
-        renderer.render(path, self, &block)
+      def render(path, scope = {}, &block)
+        renderer.render(path, self.with(scope), &block)
       end
 
       def template?(name)
         renderer.lookup("_#{name}")
+      end
+
+      def with(scope)
+        ValuePart.new(renderer, scope)
       end
 
       def respond_to_missing?(meth, include_private = false)
@@ -29,7 +33,7 @@ module Dry
         template_path = template?(meth)
 
         if template_path
-          render(template_path, &block)
+          render(template_path, *args, &block)
         else
           super
         end
@@ -37,3 +41,5 @@ module Dry
     end
   end
 end
+
+require 'dry/view/value_part'

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -12,7 +12,7 @@ module Dry
       end
 
       def render(path, scope = {}, &block)
-        renderer.render(path, self.with(scope), &block)
+        renderer.render(path, with(scope), &block)
       end
 
       def template?(name)
@@ -27,19 +27,29 @@ module Dry
         end
       end
 
-      def respond_to_missing?(meth, include_private = false)
-        super || template?(meth)
+      def respond_to_missing?(name, include_private = false)
+        template?(name) || super
       end
 
       private
 
-      def method_missing(meth, *args, &block)
-        template_path = template?(meth)
+      def method_missing(name, *args, &block)
+        template_path = template?(name)
 
         if template_path
-          render(template_path, *args, &block)
+          render(template_path, prepare_render_scope(name, *args), &block)
         else
           super
+        end
+      end
+
+      def prepare_render_scope(name, *args)
+        if args.none?
+          {}
+        elsif args.length == 1 && args.first.respond_to?(:to_hash)
+          args.first.to_hash
+        else
+          {name => args.length == 1 ? args.first : args}
         end
       end
     end

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -20,7 +20,11 @@ module Dry
       end
 
       def with(scope)
-        ValuePart.new(renderer, scope)
+        if scope.any?
+          ValuePart.new(renderer, scope)
+        else
+          self
+        end
       end
 
       def respond_to_missing?(meth, include_private = false)

--- a/lib/dry/view/value_part.rb
+++ b/lib/dry/view/value_part.rb
@@ -44,7 +44,7 @@ module Dry
         template_path = template?(meth)
 
         if template_path
-          render(template_path, *args, &block)
+          render(template_path, prepare_render_scope(meth, *args), &block)
         elsif _data.key?(meth)
           _data[meth]
         elsif _value.respond_to?(meth)

--- a/lib/dry/view/value_part.rb
+++ b/lib/dry/view/value_part.rb
@@ -27,7 +27,11 @@ module Dry
       end
 
       def with(scope)
-        self.class.new(renderer, _data.merge(scope))
+        if scope.any?
+          self.class.new(renderer, _data.merge(scope))
+        else
+          self
+        end
       end
 
       def respond_to_missing?(meth, include_private = false)

--- a/lib/dry/view/value_part.rb
+++ b/lib/dry/view/value_part.rb
@@ -26,6 +26,10 @@ module Dry
         _value.each(&block)
       end
 
+      def with(scope)
+        self.class.new(renderer, _data.merge(scope))
+      end
+
       def respond_to_missing?(meth, include_private = false)
         _data.key?(meth) || super
       end
@@ -36,7 +40,7 @@ module Dry
         template_path = template?(meth)
 
         if template_path
-          render(template_path, &block)
+          render(template_path, *args, &block)
         elsif _data.key?(meth)
           _data[meth]
         elsif _value.respond_to?(meth)

--- a/spec/fixtures/templates/parts_with_args.html.slim
+++ b/spec/fixtures/templates/parts_with_args.html.slim
@@ -1,0 +1,3 @@
+.users
+  - users.each do |user|
+    == user.box(label: "Nombre")

--- a/spec/fixtures/templates/parts_with_args/_box.html.slim
+++ b/spec/fixtures/templates/parts_with_args/_box.html.slim
@@ -1,0 +1,4 @@
+div.box
+  h2 = label
+  = user[:name]
+

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -52,8 +52,25 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(scope: scope, locals: {subtitle: 'Users List', users: users })).to eq(
+    expect(view.(scope: scope, locals: {subtitle: 'Users List', users: users})).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h1>OVERRIDE</h1><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    )
+  end
+
+  it 'renders a view that passes arguments to it parts' do
+    view = Class.new(view_class) do
+      configure do |config|
+        config.template = 'parts_with_args'
+      end
+    end.new
+
+    users = [
+      { name: 'Jane', email: 'jane@doe.org' },
+      { name: 'Joe', email: 'joe@doe.org' }
+    ]
+
+    expect(view.(scope: scope, locals: {users: users})).to eq(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><div class="users"><div class="box"><h2>Nombre</h2>Jane</div><div class="box"><h2>Nombre</h2>Joe</div></div></body></html>'
     )
   end
 

--- a/spec/unit/null_part_spec.rb
+++ b/spec/unit/null_part_spec.rb
@@ -13,24 +13,52 @@ RSpec.describe Dry::View::NullPart do
     end
   end
 
-  describe '#method_missing' do
-    it 'renders a template with the _missing suffix' do
-      expect(renderer).to receive(:lookup).with('_row_missing').and_return('_row_missing.slim')
-      expect(renderer).to receive(:render).with('_row_missing.slim', part)
-
-      part.row
+  describe "#with" do
+    it "builds a new instance with the extra data" do
+      expect(part.with(foo: "bar")).to eq Dry::View::NullPart.new(renderer, {user: nil, foo: "bar"})
     end
 
-    it 'renders a _missing template within another when block is passed' do
-      block = proc { part.fields }
+    it "returns self when no data passed" do
+      expect(part.with({})).to eql part
+    end
+  end
 
-      expect(renderer).to receive(:lookup).with('_form_missing').and_return('form_missing.slim')
-      expect(renderer).to receive(:lookup).with('_fields_missing').and_return('fields_missing.slim')
+  describe '#method_missing' do
+    context 'template matches' do
+      it 'renders template with the _missing suffix' do
+        expect(renderer).to receive(:lookup).with('_row_missing').and_return('_row_missing.slim')
+        expect(renderer).to receive(:render).with('_row_missing.slim', part)
 
-      expect(renderer).to receive(:render).with('form_missing.slim', part, &block)
-      expect(renderer).to receive(:render).with('fields_missing.slim', part)
+        part.row
+      end
 
-      part.form(&block)
+      it 'renders template with extra data when a hash is passed' do
+        expect(renderer).to receive(:lookup).with('_fields_missing').and_return('_fields_missing.html.slim')
+        expect(renderer).to receive(:render).with('_fields_missing.html.slim', part.with(foo: "bar"))
+
+        part.fields(foo: "bar")
+      end
+
+      it "renders template with extra data (keyed by the template's name) when any other object is passed" do
+        my_thing = Object.new
+
+        expect(renderer).to receive(:lookup).with('_fields_missing').and_return('_fields_missing.html.slim')
+        expect(renderer).to receive(:render).with('_fields_missing.html.slim', part.with(fields: my_thing))
+
+        part.fields(my_thing)
+      end
+
+      it 'renders a _missing template within another when block is passed' do
+        block = proc { part.fields }
+
+        expect(renderer).to receive(:lookup).with('_form_missing').and_return('form_missing.slim')
+        expect(renderer).to receive(:lookup).with('_fields_missing').and_return('fields_missing.slim')
+
+        expect(renderer).to receive(:render).with('form_missing.slim', part, &block)
+        expect(renderer).to receive(:render).with('fields_missing.slim', part)
+
+        part.form(&block)
+      end
     end
   end
 end

--- a/spec/unit/null_part_spec.rb
+++ b/spec/unit/null_part_spec.rb
@@ -2,11 +2,8 @@ require 'dry/view/null_part'
 
 RSpec.describe Dry::View::NullPart do
   subject(:part) do
-    Dry::View::NullPart.new(renderer, data)
+    Dry::View::NullPart.new(renderer, {user: nil})
   end
-
-  let(:name) { :user }
-  let(:data) { { user: nil } }
 
   let(:renderer) { double(:renderer) }
 
@@ -33,7 +30,7 @@ RSpec.describe Dry::View::NullPart do
       expect(renderer).to receive(:render).with('form_missing.slim', part, &block)
       expect(renderer).to receive(:render).with('fields_missing.slim', part)
 
-      part.form(block)
+      part.form(&block)
     end
   end
 end

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -1,20 +1,11 @@
-require 'dry/view/value_part'
+require 'dry/view/part'
 
-RSpec.describe Dry::View::ValuePart do
+RSpec.describe Dry::View::Part do
   subject(:part) do
-    Dry::View::ValuePart.new(renderer, data)
+    Dry::View::Part.new(renderer)
   end
-
-  let(:name) { :user }
-  let(:data) { { user: { email: 'jane@doe.org' } } }
 
   let(:renderer) { double(:renderer) }
-
-  describe '#[]' do
-    it 'gives access to data values' do
-      expect(part[:email]).to eql('jane@doe.org')
-    end
-  end
 
   describe '#render' do
     it 'renders given template' do
@@ -33,8 +24,8 @@ RSpec.describe Dry::View::ValuePart do
   end
 
   describe "#with" do
-    it "builds a new instance with the extra data" do
-      expect(part.with(foo: "bar")).to eq Dry::View::ValuePart.new(renderer, data.merge(foo: "bar"))
+    it "builds a new value part with the extra data" do
+      expect(part.with(foo: "bar")).to eq Dry::View::ValuePart.new(renderer, foo: "bar")
     end
 
     it "returns self when no data passed" do

--- a/spec/unit/value_part_spec.rb
+++ b/spec/unit/value_part_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Dry::View::ValuePart do
       expect(renderer).to receive(:render).with('form.slim', part, &block)
       expect(renderer).to receive(:render).with('fields.slim', part)
 
-      part.form(block)
+      part.form(&block)
     end
   end
 end


### PR DESCRIPTION
In a lot of the apps we work on, we've encountered a requirement to pass some data from _within a template_ to another partial. An example would be partials that require extra data or config related to how they should present themselves in a certain context, e.g. `== user.metadata_box(header_label: "Cool stats")`.

This change makes that possible. Since the arguments to the template call is still effectively _data_, this holds true to the dry-view philosophy of data-orientation.

I've still to improve the test coverage a little more, but I thought I'd throw it up now for anyone to comment on.

Code-wise, just one thing stands out: the inheritance of `Part` is getting a bit awkward, especially since we now need to transform `Part` and `NullPart` instances into `ValuePart` when they're called with args in a template. I think it might be best if we just made these all sibling classes and dropped the inheritance.
