### PR TITLE
[WIP] Allow views to be rendered without a layout

### DIFF
--- a/lib/dry/view/layout.rb
+++ b/lib/dry/view/layout.rb
@@ -23,6 +23,7 @@ module Dry
       setting :template
       setting :formats, { html: :erb }
       setting :scope
+      setting :layout, true
 
       attr_reader :config, :scope, :layout_dir, :layout_path, :template_path,
         :default_format
@@ -65,16 +66,15 @@ module Dry
         @layout_path = "#{layout_dir}/#{config.name}"
         @template_path = config.template
         @scope = config.scope
+        @use_layout = config.layout
       end
 
       def call(options = {})
-        use_layout = options.fetch(:layout) { true }
-
         renderer = self.class.renderer(options.fetch(:format, default_format))
 
         template_content = renderer.(template_path, template_scope(options, renderer))
 
-        return template_content unless use_layout
+        return template_content unless @use_layout
 
         renderer.(layout_path, layout_scope(options, renderer)) do
           template_content

--- a/lib/dry/view/layout.rb
+++ b/lib/dry/view/layout.rb
@@ -68,9 +68,13 @@ module Dry
       end
 
       def call(options = {})
+        use_layout = options.fetch(:layout) { true }
+
         renderer = self.class.renderer(options.fetch(:format, default_format))
 
         template_content = renderer.(template_path, template_scope(options, renderer))
+
+        return template_content unless use_layout
 
         renderer.(layout_path, layout_scope(options, renderer)) do
           template_content

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe 'dry-view' do
     )
   end
 
+  it 'renders without a layout when layout=false' do
+    view = view_class.new
+
+    users = [
+      { name: 'Jane', email: 'jane@doe.org' },
+      { name: 'Joe', email: 'joe@doe.org' }
+    ]
+
+    expect(view.(layout: false, locals: { subtitle: "Users List", users: users })).to eql(
+      '<h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div>'
+    )
+  end
+
   it 'renders a view with an alternative format and engine' do
     view = view_class.new
 

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -28,14 +28,18 @@ RSpec.describe 'dry-view' do
   end
 
   it 'renders without a layout when layout=false' do
-    view = view_class.new
+    view = Class.new(view_class) do
+      configure do |config|
+        config.layout = false
+      end
+    end.new
 
     users = [
       { name: 'Jane', email: 'jane@doe.org' },
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(layout: false, locals: { subtitle: "Users List", users: users })).to eql(
+    expect(view.(locals: { subtitle: "Users List", users: users })).to eql(
       '<h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div>'
     )
   end


### PR DESCRIPTION
This PR allows the rendering of views without rendering a template by doing:

``` ruby
class Feed < View
  configure do |config|
    config.layout = false
    config.template = "pages/xml_feed"
  end
  #...snip...
end
```

I'm not sure if short circuiting `Layout#call` is the most elegant solution, and open for suggestions as to any improvements there.
