### PR TITLE
Rename layout to controller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,21 @@
 language: ruby
+dist: trusty
 sudo: false
 cache: bundler
 bundler_args: --without tools benchmarks
 script:
-  - bundle exec rake spec
+  - bundle exec rake
+after_success:
+  - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3.0
-  - rbx
-  - jruby-9000
-  - ruby-head
-  - jruby-head
+  - 2.3.1
+  - jruby-9.1.5.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
 notifications:
   email: false
   webhooks:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,8 @@ group :test do
   gem 'rack', '>= 1.0.0', '<= 2.0.0'
   gem 'slim'
 
-  gem 'codeclimate-test-reporter', platform: :rbx
+  gem 'simplecov'
+  gem 'codeclimate-test-reporter'
 end
 
 group :benchmarks do

--- a/lib/dry/view.rb
+++ b/lib/dry/view.rb
@@ -1,2 +1,2 @@
 require 'dry/view/renderer'
-require 'dry/view/layout'
+require 'dry/view/controller'

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -81,7 +81,9 @@ module Dry
         options.fetch(:locals, {})
       end
 
-      def parts(locals, renderer)
+      private
+
+      def view_parts(locals, renderer)
         return empty_part(template_path, renderer) unless locals.any?
 
         part_hash = locals.each_with_object({}) do |(key, value), result|
@@ -104,8 +106,6 @@ module Dry
         part(template_path, renderer, part_hash)
       end
 
-      private
-
       def layout_scope(options, renderer)
         part_hash = {
           page: layout_part(:page, renderer, options.fetch(:scope, scope))
@@ -115,7 +115,7 @@ module Dry
       end
 
       def template_scope(options, renderer)
-        parts(locals(options), renderer)
+        view_parts(locals(options), renderer)
       end
 
       def layout_part(name, renderer, value)

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -10,7 +10,7 @@ require 'dry/view/renderer'
 
 module Dry
   module View
-    class Layout
+    class Controller
       include Dry::Equalizer(:config)
 
       DEFAULT_DIR = 'layouts'.freeze
@@ -31,7 +31,7 @@ module Dry
         super(&block)
 
         if config.root
-          warn "[DEPRECATION] Dry::View::Layout `root` setting is deprecated.  Please use `paths` instead."
+          warn "[DEPRECATION] Dry::View::Controller `root` setting is deprecated.  Please use `paths` instead."
           config.paths = config.root unless config.paths
         end
       end

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -19,7 +19,7 @@ module Dry
 
       setting :root # deprecated
       setting :paths
-      setting :name
+      setting :layout
       setting :template
       setting :formats, { html: :erb }
       setting :scope
@@ -62,7 +62,7 @@ module Dry
         @config = self.class.config
         @default_format = self.class.default_format
         @layout_dir = DEFAULT_DIR
-        @layout_path = "#{layout_dir}/#{config.name}"
+        @layout_path = "#{layout_dir}/#{config.layout}"
         @template_path = config.template
         @scope = config.scope
       end

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'dry-view' do
     Class.new(Dry::View::Controller) do
       configure do |config|
         config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.name = 'app'
+        config.layout = 'app'
         config.template = 'users'
         config.formats = {html: :slim, txt: :erb}
       end
@@ -79,7 +79,7 @@ RSpec.describe 'dry-view' do
       klass = Class.new(Dry::View::Controller)
 
       klass.setting :paths, SPEC_ROOT.join('fixtures/templates')
-      klass.setting :name, 'app'
+      klass.setting :layout, 'app'
       klass.setting :formats, {html: :slim}
 
       klass

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'dry-view' do
   let(:view_class) do
-    Class.new(Dry::View::Layout) do
+    Class.new(Dry::View::Controller) do
       configure do |config|
         config.paths = SPEC_ROOT.join('fixtures/templates')
         config.name = 'app'
@@ -76,7 +76,7 @@ RSpec.describe 'dry-view' do
 
   describe 'inheritance' do
     let(:parent_view) do
-      klass = Class.new(Dry::View::Layout)
+      klass = Class.new(Dry::View::Controller)
 
       klass.setting :paths, SPEC_ROOT.join('fixtures/templates')
       klass.setting :name, 'app'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
-if RUBY_ENGINE == "rbx"
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
+if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.3'
+  require 'simplecov'
+  SimpleCov.start
 end
 
 begin

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -33,23 +33,4 @@ RSpec.describe Dry::View::Controller do
       )
     end
   end
-
-  describe '#parts' do
-    it 'returns view parts' do
-      part = layout.parts({ user: { id: 1, name: 'Jane' } }, renderer)
-
-      expect(part[:id]).to be(1)
-      expect(part[:name]).to eql('Jane')
-    end
-
-    it 'builds null parts for nil values' do
-      part = layout.parts({ user: nil }, renderer)
-
-      expect(part[:id]).to be_nil
-    end
-
-    it 'returns empty part when no locals are passed' do
-      expect(layout.parts({}, renderer)).to be_instance_of(Dry::View::Part)
-    end
-  end
 end

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dry::View::Controller do
 
     klass.configure do |config|
       config.paths = SPEC_ROOT.join('fixtures/templates')
-      config.name = 'app'
+      config.layout = 'app'
       config.template = 'user'
       config.formats = {html: :slim}
     end

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -1,8 +1,8 @@
-RSpec.describe Dry::View::Layout do
+RSpec.describe Dry::View::Controller do
   subject(:layout) { layout_class.new }
 
   let(:layout_class) do
-    klass = Class.new(Dry::View::Layout)
+    klass = Class.new(Dry::View::Controller)
 
     klass.configure do |config|
       config.paths = SPEC_ROOT.join('fixtures/templates')


### PR DESCRIPTION
This is the first step in reorienting people’s approach to dry-view. Since the main job of `Dry::View::Layout` subclasses is to assemble dependencies, accept and process input, then prepare a list of locals for a view, the “controller” name is a better reflection of its actual work. This should also hopefully make people feel more comfortable with the idea that it's OK to inject a bunch of dependencies here, even though the end-result is "view"-related. In this new arrangement, the "view" is just the template, all of the Ruby stuff is part of a "view controller".