### PR TITLE
Exposures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ bundler_args: --without tools benchmarks
 script:
   - bundle exec rake
 after_success:
-  - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
+    # Send coverage report from the job #1 == current MRI release
+  - '[ "${TRAVIS_JOB_NUMBER#*.}" = "1" ] && [ "$TRAVIS_BRANCH" = "master" ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.0
-  - 2.1.10
-  - 2.2.6
-  - 2.3.3
   - 2.4.0
+  - 2.3.3
+  - 2.2.6
+  - 2.1.10
+  - 2.0
   - jruby-9.1.5.0
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
   - 2.0
-  - 2.1
-  - 2.2
-  - 2.3.1
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
   - jruby-9.1.5.0
 env:
   global:

--- a/dry-view.gemspec
+++ b/dry-view.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.0.0'
+
   spec.add_runtime_dependency "inflecto", "~> 0"
   spec.add_runtime_dependency "tilt", "~> 2.0"
   spec.add_runtime_dependency "dry-configurable", "~> 0.1"

--- a/dry-view.gemspec
+++ b/dry-view.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.1"
-  spec.add_development_dependency "capybara", "~> 2.5"
 end

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -54,12 +54,18 @@ module Dry
         config.formats.keys.first
       end
 
-      def self.expose(name, &block)
-        exposures.add(name, block)
+      def self.expose(*names, **options, &block)
+        if names.length == 1
+          exposures.add(names.first, block, **options)
+        else
+          names.each do |name|
+            exposures.add(name, nil, **options)
+          end
+        end
       end
 
-      def self.private_expose(name, &block)
-        exposures.add(name, block, to_view: false)
+      def self.private_expose(*names, &block)
+        expose(*names, to_view: false, &block)
       end
 
       def self.exposures

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -54,8 +54,8 @@ module Dry
         config.formats.keys.first
       end
 
-      def self.expose(name, &block)
-        exposures.add(name, &block)
+      def self.expose(name, options = {}, &block)
+        exposures.add(name, block, **options)
       end
 
       def self.exposures

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -3,6 +3,7 @@ require 'dry-equalizer'
 require 'inflecto'
 
 require 'dry/view/path'
+require 'dry/view/exposures'
 require 'dry/view/part'
 require 'dry/view/value_part'
 require 'dry/view/null_part'
@@ -49,11 +50,11 @@ module Dry
       end
 
       def self.expose(name, &block)
-        exposures << [name, block]
+        exposures.add name, &block
       end
 
       def self.exposures
-        @exposures ||= []
+        @exposures ||= Exposures.new
       end
 
       def initialize
@@ -76,16 +77,10 @@ module Dry
       end
 
       def locals(options = {})
-        exposed_locals(options).merge(options.fetch(:locals, {}))
+        self.class.exposures.locals(options).merge(options.fetch(:locals, {}))
       end
 
       private
-
-      def exposed_locals(input)
-        self.class.exposures.each_with_object({}) { |(name, block), memo|
-          memo[name] = block ? instance_exec(input, &block) : __send__(name, input)
-        }
-      end
 
       def layout_scope(options, renderer)
         part_hash = {

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -54,8 +54,12 @@ module Dry
         config.formats.keys.first
       end
 
-      def self.expose(name, options = {}, &block)
-        exposures.add(name, block, **options)
+      def self.expose(name, &block)
+        exposures.add(name, block)
+      end
+
+      def self.private_expose(name, &block)
+        exposures.add(name, block, to_view: false)
       end
 
       def self.exposures

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -24,8 +24,13 @@ module Dry
       setting :formats, { html: :erb }
       setting :scope
 
-      attr_reader :config, :scope, :layout_dir, :layout_path, :template_path,
-        :default_format
+      attr_reader :config
+      attr_reader :scope
+      attr_reader :layout_dir
+      attr_reader :layout_path
+      attr_reader :template_path
+      attr_reader :default_format
+      attr_reader :exposures
 
       def self.paths
         Array(config.paths).map { |path| Dry::View::Path.new(path) }
@@ -50,7 +55,7 @@ module Dry
       end
 
       def self.expose(name, &block)
-        exposures.add name, &block
+        exposures.add(name, &block)
       end
 
       def self.exposures
@@ -64,6 +69,7 @@ module Dry
         @layout_path = "#{layout_dir}/#{config.layout}"
         @template_path = config.template
         @scope = config.scope
+        @exposures = self.class.exposures.bind(self)
       end
 
       def call(options = {})
@@ -77,7 +83,7 @@ module Dry
       end
 
       def locals(options = {})
-        self.class.exposures.locals(options).merge(options.fetch(:locals, {}))
+        exposures.locals(options).merge(options.fetch(:locals, {}))
       end
 
       private

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -3,21 +3,25 @@ module Dry
     class Exposure
       attr_reader :name
       attr_reader :block
+      attr_reader :to_view
 
-      def initialize(name, block)
+      def initialize(name, block, to_view: true)
         # TODO: raise error if block parameters aren't right
 
         @name = name
         @block = block
+        @to_view = to_view
       end
 
       def bind(obj)
-        block ? self : self.class.new(name, obj.method(name))
+        block ? self : with_block(obj.method(name))
       end
 
       def dependencies
         block.parameters.map(&:last)
       end
+
+      alias_method :to_view?, :to_view
 
       def call(input, locals)
         params = dependencies.map { |name|
@@ -25,6 +29,12 @@ module Dry
         }
 
         block.(*params)
+      end
+
+      private
+
+      def with_block(block)
+        self.class.new(name, block, to_view: to_view)
       end
     end
   end

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -1,6 +1,8 @@
 module Dry
   module View
     class Exposure
+      SUPPORTED_PARAMETER_TYPES = [:req, :opt].freeze
+
       attr_reader :name
       attr_reader :proc
       attr_reader :to_view
@@ -38,8 +40,9 @@ module Dry
       end
 
       def ensure_proc_parameters(proc)
-        raise ArgumentError, "+proc+ must take at least one argument" if proc.parameters.empty?
-        raise ArgumentError, "+proc+ must take positional arugments only" if proc.parameters.any? { |type, _| type != :req }
+        if proc.parameters.any? { |type, _| !SUPPORTED_PARAMETER_TYPES.include?(type) }
+          raise ArgumentError, "+proc+ must take positional arugments only"
+        end
       end
     end
   end

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -2,39 +2,39 @@ module Dry
   module View
     class Exposure
       attr_reader :name
-      attr_reader :block
+      attr_reader :proc
       attr_reader :to_view
 
-      def initialize(name, block, to_view: true)
-        # TODO: raise error if block parameters aren't right
+      def initialize(name, proc = nil, to_view: true)
+        # TODO: raise error if proc parameters aren't right
 
         @name = name
-        @block = block
+        @proc = proc
         @to_view = to_view
       end
 
       def bind(obj)
-        block ? self : with_block(obj.method(name))
+        proc ? self : with_proc(obj.method(name))
       end
 
       def dependencies
-        block.parameters.map(&:last)
+        proc.parameters.map(&:last)
       end
 
       alias_method :to_view?, :to_view
 
-      def call(input, locals)
+      def call(input, locals = {})
         params = dependencies.map { |name|
           name == :input ? input : locals.fetch(name)
         }
 
-        block.(*params)
+        proc.(*params)
       end
 
       private
 
-      def with_block(block)
-        self.class.new(name, block, to_view: to_view)
+      def with_proc(proc)
+        self.class.new(name, proc, to_view: to_view)
       end
     end
   end

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -1,12 +1,18 @@
 module Dry
   module View
     class Exposure
+      attr_reader :name
       attr_reader :block
 
-      def initialize(block)
+      def initialize(name, block)
         # TODO: raise error if block parameters aren't right
 
+        @name = name
         @block = block
+      end
+
+      def bind(obj)
+        block ? self : self.class.new(name, obj.method(name))
       end
 
       def dependencies

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -6,7 +6,7 @@ module Dry
       attr_reader :to_view
 
       def initialize(name, proc = nil, to_view: true)
-        # TODO: raise error if proc parameters aren't right
+        ensure_proc_parameters(proc) if proc
 
         @name = name
         @proc = proc
@@ -35,6 +35,11 @@ module Dry
 
       def with_proc(proc)
         self.class.new(name, proc, to_view: to_view)
+      end
+
+      def ensure_proc_parameters(proc)
+        raise ArgumentError, "+proc+ must take at least one argument" if proc.parameters.empty?
+        raise ArgumentError, "+proc+ must take positional arugments only" if proc.parameters.any? { |type, _| type != :req }
       end
     end
   end

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -26,8 +26,12 @@ module Dry
       alias_method :to_view?, :to_view
 
       def call(input, locals = {})
-        params = dependencies.map { |name|
-          name == :input ? input : locals.fetch(name)
+        params = dependencies.map.with_index.map { |name, position|
+          if position.zero?
+            locals.fetch(name) { input }
+          else
+            locals.fetch(name)
+          end
         }
 
         proc.(*params)

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -1,0 +1,25 @@
+module Dry
+  module View
+    class Exposure
+      attr_reader :block
+
+      def initialize(block)
+        # TODO: raise error if block parameters aren't right
+
+        @block = block
+      end
+
+      def dependencies
+        block.parameters.map(&:last)
+      end
+
+      def call(input, locals)
+        params = dependencies.map { |name|
+          name == :input ? input : locals.fetch(name)
+        }
+
+        block.(*params)
+      end
+    end
+  end
+end

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -12,8 +12,8 @@ module Dry
         @exposures = exposures
       end
 
-      def add(name, &block)
-        @exposures[name] = Exposure.new(name, block)
+      def add(name, block, **options)
+        @exposures[name] = Exposure.new(name, block, **options)
       end
 
       def bind(obj)
@@ -27,6 +27,8 @@ module Dry
       def locals(input)
         tsort.each_with_object({}) { |name, memo|
           memo[name] = exposures[name].(input, memo) if exposures.key?(name)
+        }.each_with_object({}) { |(name, val), memo|
+          memo[name] = val if exposures[name].to_view?
         }
       end
 

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -1,0 +1,36 @@
+require "tsort"
+require "dry/view/exposure"
+
+module Dry
+  module View
+    class Exposures
+      include TSort
+
+      attr_reader :exposures
+
+      def initialize
+        @exposures = {}
+      end
+
+      def add(name, &block)
+        @exposures[name] = Exposure.new(block)
+      end
+
+      def locals(input)
+        tsort.each_with_object({}) { |name, memo|
+          memo[name] = exposures[name].(input, memo) if exposures.key?(name)
+        }
+      end
+
+      private
+
+      def tsort_each_node(&block)
+        exposures.each_key(&block)
+      end
+
+      def tsort_each_child(name, &block)
+        exposures[name].dependencies.each(&block) if exposures.key?(name)
+      end
+    end
+  end
+end

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -17,9 +17,9 @@ module Dry
       end
 
       def bind(obj)
-        bound_exposures = exposures.map { |name, exposure|
+        bound_exposures = Hash[exposures.map { |name, exposure|
           [name, exposure.bind(obj)]
-        }.to_h
+        }]
 
         self.class.new(bound_exposures)
       end

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -12,8 +12,8 @@ module Dry
         @exposures = exposures
       end
 
-      def add(name, block, **options)
-        @exposures[name] = Exposure.new(name, block, **options)
+      def add(name, proc = nil, **options)
+        @exposures[name] = Exposure.new(name, proc, **options)
       end
 
       def bind(obj)

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -8,12 +8,20 @@ module Dry
 
       attr_reader :exposures
 
-      def initialize
-        @exposures = {}
+      def initialize(exposures = {})
+        @exposures = exposures
       end
 
       def add(name, &block)
-        @exposures[name] = Exposure.new(block)
+        @exposures[name] = Exposure.new(name, block)
+      end
+
+      def bind(obj)
+        bound_exposures = exposures.map { |name, exposure|
+          [name, exposure.bind(obj)]
+        }.to_h
+
+        self.class.new(bound_exposures)
       end
 
       def locals(input)

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -12,8 +12,12 @@ module Dry
         @exposures = exposures
       end
 
+      def [](name)
+        exposures[name]
+      end
+
       def add(name, proc = nil, **options)
-        @exposures[name] = Exposure.new(name, proc, **options)
+        exposures[name] = Exposure.new(name, proc, **options)
       end
 
       def bind(obj)
@@ -26,9 +30,9 @@ module Dry
 
       def locals(input)
         tsort.each_with_object({}) { |name, memo|
-          memo[name] = exposures[name].(input, memo) if exposures.key?(name)
+          memo[name] = self[name].(input, memo) if exposures.key?(name)
         }.each_with_object({}) { |(name, val), memo|
-          memo[name] = val if exposures[name].to_view?
+          memo[name] = val if self[name].to_view?
         }
       end
 
@@ -39,7 +43,7 @@ module Dry
       end
 
       def tsort_each_child(name, &block)
-        exposures[name].dependencies.each(&block) if exposures.key?(name)
+        self[name].dependencies.each(&block) if exposures.key?(name)
       end
     end
   end

--- a/spec/fixtures/templates/users_with_count.html.slim
+++ b/spec/fixtures/templates/users_with_count.html.slim
@@ -1,0 +1,7 @@
+h2 = subtitle
+
+ul
+  - users.each do |user|
+    li = "#{user[:name]} (#{user[:email]})"
+
+.count = users_count

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -84,4 +84,41 @@ RSpec.describe 'exposures' do
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">2 users</div></body></html>'
     )
   end
+
+  it 'allows exposures to be hidden from the view' do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'users_with_count'
+        config.formats = {html: :slim}
+      end
+
+      expose :prefix, to_view: false do
+        "COUNT: "
+      end
+
+      expose :users do |input|
+        input.fetch(:users)
+      end
+
+      expose :users_count do |prefix, users|
+        "#{prefix}#{users.length} users"
+      end
+    end.new
+
+    users = [
+      {name: 'Jane', email: 'jane@doe.org'},
+      {name: 'Joe', email: 'joe@doe.org'}
+    ]
+
+    input = {users: users, scope: scope, locals: {subtitle: 'Users List'}}
+
+    expect(vc.(input)).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">COUNT: 2 users</div></body></html>'
+    )
+
+    expect(vc.locals(input)).to include(:users, :users_count)
+    expect(vc.locals(input)).not_to include(:prefix)
+  end
 end

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe 'exposures' do
+  let(:view_controller) {
+    Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'users'
+        config.formats = {html: :slim, txt: :erb}
+      end
+
+      expose :users do |input|
+        input.fetch(:users).map { |user|
+          user.merge(name: user[:name].upcase)
+        }
+      end
+    end.new
+  }
+
+  let(:scope) {
+    Struct.new(:title).new('dry-view rocks!')
+  }
+
+  it 'uses exposures to build view locals' do
+    users = [
+      { name: 'Jane', email: 'jane@doe.org' },
+      { name: 'Joe', email: 'joe@doe.org' }
+    ]
+
+    expect(view_controller.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    )
+  end
+end

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe 'exposures' do
-  let(:view_controller) {
-    Class.new(Dry::View::Controller) do
+  let(:scope) { Struct.new(:title).new('dry-view rocks!') }
+
+  it 'uses exposures to build view locals' do
+    vc = Class.new(Dry::View::Controller) do
       configure do |config|
         config.paths = SPEC_ROOT.join('fixtures/templates')
         config.layout = 'app'
@@ -14,19 +16,43 @@ RSpec.describe 'exposures' do
         }
       end
     end.new
-  }
 
-  let(:scope) {
-    Struct.new(:title).new('dry-view rocks!')
-  }
-
-  it 'uses exposures to build view locals' do
     users = [
       { name: 'Jane', email: 'jane@doe.org' },
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view_controller.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    )
+  end
+
+  it 'supports both blocks and instance methods as exposures' do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'users'
+        config.formats = {html: :slim}
+      end
+
+      expose :users
+
+      private
+
+      def users(input)
+        input.fetch(:users).map { |user|
+          user.merge(name: user[:name].upcase)
+        }
+      end
+    end.new
+
+    users = [
+      { name: 'Jane', email: 'jane@doe.org' },
+      { name: 'Joe', email: 'joe@doe.org' }
+    ]
+
+    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -85,6 +85,38 @@ RSpec.describe 'exposures' do
     )
   end
 
+  it 'supports defining multiple exposures at once' do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'users_with_count'
+        config.formats = {html: :slim}
+      end
+
+      expose :users, :users_count
+
+      private
+
+      def users(input)
+        input.fetch(:users)
+      end
+
+      def users_count(users)
+        "#{users.length} users"
+      end
+    end.new
+
+    users = [
+      {name: 'Jane', email: 'jane@doe.org'},
+      {name: 'Joe', email: 'joe@doe.org'}
+    ]
+
+    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">2 users</div></body></html>'
+    )
+  end
+
   it 'allows exposures to be hidden from the view' do
     vc = Class.new(Dry::View::Controller) do
       configure do |config|

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'exposures' do
         config.formats = {html: :slim}
       end
 
-      expose :prefix, to_view: false do
+      private_expose :prefix do
         "COUNT: "
       end
 

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'exposures' do
         config.paths = SPEC_ROOT.join('fixtures/templates')
         config.layout = 'app'
         config.template = 'users'
-        config.formats = {html: :slim, txt: :erb}
+        config.formats = {html: :slim}
       end
 
       expose :users do |input|
@@ -28,6 +28,34 @@ RSpec.describe 'exposures' do
 
     expect(view_controller.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    )
+  end
+
+  it 'allows exposures to depend on each other' do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'users_with_count'
+        config.formats = {html: :slim}
+      end
+
+      expose :users do |input|
+        input.fetch(:users)
+      end
+
+      expose :users_count do |users|
+        "#{users.length} users"
+      end
+    end.new
+
+    users = [
+      {name: 'Jane', email: 'jane@doe.org'},
+      {name: 'Joe', email: 'joe@doe.org'}
+    ]
+
+    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">2 users</div></body></html>'
     )
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.3'
+if RUBY_ENGINE == 'ruby'
   require 'simplecov'
   SimpleCov.start
 end

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Dry::View::Exposure do
         expect(described_class.new(:hello).proc).to be_nil
       end
 
-      it "requires proc to take at least one arguemnt" do
+      it "allows proc to take no arguments" do
         proc = -> { "hi" }
-        expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
+        expect { described_class.new(:hello, proc) }.not_to raise_error
       end
 
       it "requires proc to take positional arguments only" do
@@ -29,11 +29,6 @@ RSpec.describe Dry::View::Exposure do
         expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
 
         proc = -> input, a: { "hi" }
-        expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
-      end
-
-      it "requires the proc's arguments to have no default values" do
-        proc = -> input = "hi" { input }
         expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
       end
     end

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -20,9 +20,21 @@ RSpec.describe Dry::View::Exposure do
       end
 
       it "requires proc to take at least one arguemnt" do
+        proc = -> { "hi" }
+        expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
       end
 
       it "requires proc to take positional arguments only" do
+        proc = -> a: { "hi" }
+        expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
+
+        proc = -> input, a: { "hi" }
+        expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
+      end
+
+      it "requires the proc's arguments to have no default values" do
+        proc = -> input = "hi" { input }
+        expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
       end
     end
 

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -1,0 +1,129 @@
+RSpec.describe Dry::View::Exposure do
+  subject(:exposure) { described_class.new(:hello, proc) }
+
+  let(:proc) { -> input { "hi" } }
+
+  describe "initialization and attributes" do
+    describe "#name" do
+      it "accepts a name" do
+        expect(exposure.name).to eql :hello
+      end
+    end
+
+    describe "#proc" do
+      it "accepts a proc" do
+        expect(exposure.proc).to eql proc
+      end
+
+      it "allows a nil proc" do
+        expect(described_class.new(:hello).proc).to be_nil
+      end
+
+      it "requires proc to take at least one arguemnt" do
+      end
+
+      it "requires proc to take positional arguments only" do
+      end
+    end
+
+    describe "#to_view" do
+      it "is true by default" do
+        expect(exposure.to_view).to be true
+      end
+
+      it "can be set to false on initialization" do
+        expect(described_class.new(:hello, to_view: false).to_view).to be false
+      end
+    end
+  end
+
+  describe "#bind" do
+    context "proc provided" do
+      subject(:bound_exposure) { exposure.bind(Object.new) }
+
+      it "returns itself" do
+        expect(bound_exposure).to eql exposure
+      end
+
+      it "retains the same proc" do
+        expect(bound_exposure.proc).to eql proc
+      end
+    end
+
+    context "no proc provided" do
+      subject(:bound_exposure) { exposure.bind(object) }
+
+      let(:exposure) { described_class.new(:hello) }
+
+      let(:object) do
+        Class.new do
+          def hello(input)
+            "hi there, #{input.fetch(:name)}"
+          end
+        end.new
+      end
+
+      it "returns a new object" do
+        expect(bound_exposure).not_to eql exposure
+      end
+
+      it "sets the proc to the method on the object matching the exposure's name" do
+        expect(bound_exposure.proc).to eql object.method(:hello)
+      end
+
+      it "raises an error if the object has no matching method" do
+        expect { described_class.new(:something_else).bind(object) }.to raise_error NameError
+      end
+    end
+  end
+
+  describe "#dependencies" do
+    let(:proc) { -> input, foo, bar { "hi" } }
+
+    it "returns an array of exposure dependencies derived from the proc's argument names" do
+      expect(exposure.dependencies).to eql [:input, :foo, :bar]
+    end
+  end
+
+  describe "#call" do
+    let(:input) { double("input") }
+
+    before do
+      allow(proc).to receive(:call)
+    end
+
+    context "proc expects input only" do
+      it "sends the input to the proc" do
+        exposure.(input)
+
+        expect(proc).to have_received(:call).with(input)
+      end
+    end
+
+    context "proc expects input and dependencies" do
+      let(:proc) { -> input, greeting { "#{greeting}, #{input.fetch(:name)}" } }
+      let(:locals) { {greeting: "Hola"} }
+
+      before do
+        exposure.(input, locals)
+      end
+
+      it "sends the input and dependency values to the proc" do
+        expect(proc).to have_received(:call).with(input, "Hola")
+      end
+    end
+
+    context "proc expects dependencies only" do
+      let(:proc) { -> greeting, farewell { "#{greeting}, #{input.fetch(:name)}" } }
+      let(:locals) { {greeting: "Hola", farewell: "Adios"} }
+
+      before do
+        exposure.(input, locals)
+      end
+
+      it "sends the dependency values to the proc" do
+        expect(proc).to have_received(:call).with "Hola", "Adios"
+      end
+    end
+  end
+end

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe Dry::View::Exposure do
       end
 
       it "requires proc to take positional arguments only" do
-        proc = -> a: { "hi" }
+        proc = -> a: "a" { "hi" }
         expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
 
-        proc = -> input, a: { "hi" }
+        proc = -> input, a: "a" { "hi" }
         expect { described_class.new(:hello, proc) }.to raise_error ArgumentError
       end
     end

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe Dry::View::Exposures do
+  subject(:exposures) { described_class.new }
+
+  describe "#exposures" do
+    it "is empty by defalut" do
+      expect(exposures.exposures).to be_empty
+    end
+  end
+
+  describe "#add" do
+    it "creates and adds an exposure" do
+      proc = -> input { "hi" }
+      exposures.add :hello, proc
+
+      expect(exposures.exposures[:hello].name).to eq :hello
+      expect(exposures.exposures[:hello].proc).to eq proc
+    end
+  end
+
+  describe "#bind" do
+    subject(:bound_exposures) { exposures.bind(object) }
+
+    let(:object) do
+      Class.new do
+        def hello(input)
+          "hi"
+        end
+      end.new
+    end
+
+    before do
+      exposures.add(:hello)
+    end
+
+    it "binds each of the exposures" do
+      expect(bound_exposures.exposures[:hello].proc).to eq object.method(:hello)
+    end
+
+    it "returns a new copy of the exposures" do
+      expect(exposures.exposures).not_to eql(bound_exposures.exposures)
+    end
+  end
+
+  describe "#locals" do
+    before do
+      exposures.add(:greeting, -> input { input.fetch(:greeting).upcase })
+      exposures.add(:farewell, -> greeting { "#{greeting} and goodbye" })
+    end
+
+    subject(:locals) { exposures.locals(greeting: "hello") }
+
+    it "returns the values from the exposures' procs" do
+      expect(locals).to eq(greeting: "HELLO", farewell: "HELLO and goodbye")
+    end
+
+    it "does not return any values from private exposures" do
+      exposures.add(:hidden, -> input { "shh" }, to_view: false)
+
+      expect(locals).to include(:greeting, :farewell)
+      expect(locals).not_to include(:hidden)
+    end
+  end
+end

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Dry::View::Exposures do
       proc = -> input { "hi" }
       exposures.add :hello, proc
 
-      expect(exposures.exposures[:hello].name).to eq :hello
-      expect(exposures.exposures[:hello].proc).to eq proc
+      expect(exposures[:hello].name).to eq :hello
+      expect(exposures[:hello].proc).to eq proc
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe Dry::View::Exposures do
     end
 
     it "binds each of the exposures" do
-      expect(bound_exposures.exposures[:hello].proc).to eq object.method(:hello)
+      expect(bound_exposures[:hello].proc).to eq object.method(:hello)
     end
 
     it "returns a new copy of the exposures" do


### PR DESCRIPTION
So far, we have basic support for exposures to accept input and supply view locals.

There's still some to do:

- [x] Inspect exposure method/block parameter names to pass the results of other exposures
- [x] Allow exposures to be defined as blocks or with instance methods
- [x] Memoize exposures
- [x] "Private" exposures (returning e.g. a common object used by multiple other exposures, but not necessary to pass to the view itself)
- [x] Allow multiple exposures to be defined in a single line (e.g. `expose :foo, :bar, :baz`)
- [ ] Documentation

This will resolve #14.