### PR TITLE
Make message for TemplateNotFoundError more readable

### DIFF
--- a/lib/dry/view/renderer.rb
+++ b/lib/dry/view/renderer.rb
@@ -27,7 +27,7 @@ module Dry
         if path
           render(path, scope, &block)
         else
-          msg = "Template #{template} could not be found in paths:\n#{paths.map { |pa| "- #{pa}" }.join("\n")}"
+          msg = "Template #{template.inspect} could not be found in paths:\n#{paths.map { |pa| "- #{pa.to_s}" }.join("\n")}"
           raise TemplateNotFoundError, msg
         end
       end


### PR DESCRIPTION
Before
```
Dry::View::Renderer::TemplateNotFoundError
Template login_forms could not be found in paths: - #<Dry::View::Path:0x007fb176abb5b0>
```
After
```
Dry::View::Renderer::TemplateNotFoundError
Template "login_forms" could not be found in paths: - /Users/kwando/projects/rpc_web/templates
```