### PR TITLE
Unify handling of additional partial args and run through Part.build

### DIFF
--- a/lib/dry/view/null_part.rb
+++ b/lib/dry/view/null_part.rb
@@ -9,25 +9,17 @@ module Dry
       def each(&block)
       end
 
-      def with(scope)
-        if scope.any?
-          self.class.new(renderer, _data.merge(scope))
-        else
-          self
-        end
-      end
-
       def respond_to_missing?(*)
         true
       end
 
       private
 
-      def method_missing(meth, *args, &block)
-        template_path = template?("#{meth}_missing")
+      def method_missing(name, *args, &block)
+        template_path = template?("#{name}_missing")
 
         if template_path
-          render(template_path, prepare_render_scope(meth, *args), &block)
+          render(template_path, *args, &block)
         else
           nil
         end

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -28,8 +28,8 @@ module Dry
         @renderer = renderer
       end
 
-      def render(path, *additional_scope, &block)
-        renderer.render(path, _with(_render_scope(*additional_scope)), &block)
+      def render(path, *scope_args, &block)
+        renderer.render(path, _with(_render_scope(*scope_args)), &block)
       end
 
       def template?(name)

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -28,20 +28,12 @@ module Dry
         @renderer = renderer
       end
 
-      def render(path, scope = {}, &block)
-        renderer.render(path, with(scope), &block)
+      def render(path, *additional_scope, &block)
+        renderer.render(path, _with(_render_scope(*additional_scope)), &block)
       end
 
       def template?(name)
         renderer.lookup("_#{name}")
-      end
-
-      def with(scope)
-        if scope.any?
-          ValuePart.new(renderer, scope)
-        else
-          self
-        end
       end
 
       def respond_to_missing?(name, include_private = false)
@@ -54,19 +46,23 @@ module Dry
         template_path = template?(name)
 
         if template_path
-          render(template_path, prepare_render_scope(name, *args), &block)
+          render(template_path, *args, &block)
         else
           super
         end
       end
 
-      def prepare_render_scope(name, *args)
-        if args.none?
+      def _with(additional_scope)
+        self.class.build(renderer: renderer, value: additional_scope)
+      end
+
+      def _render_scope(*args)
+        if args.empty?
           {}
         elsif args.length == 1 && args.first.respond_to?(:to_hash)
           args.first.to_hash
         else
-          {name => args.length == 1 ? args.first : args}
+          raise ArgumentError, "render arguments must be a Hash"
         end
       end
     end

--- a/lib/dry/view/value_part.rb
+++ b/lib/dry/view/value_part.rb
@@ -26,25 +26,27 @@ module Dry
         _value.each(&block)
       end
 
-      def with(scope)
-        if scope.any?
-          self.class.new(renderer, _data.merge(scope))
-        else
-          self
-        end
-      end
-
       def respond_to_missing?(meth, include_private = false)
         _data.key?(meth) || super
       end
 
       private
 
+      def _with(additional_scope)
+        new_scope = _data.merge(additional_scope)
+
+        if new_scope != _data
+          self.class.build(renderer: renderer, value: new_scope)
+        else
+          self
+        end
+      end
+
       def method_missing(meth, *args, &block)
         template_path = template?(meth)
 
         if template_path
-          render(template_path, prepare_render_scope(meth, *args), &block)
+          render(template_path, *args, &block)
         elsif _data.key?(meth)
           _data[meth]
         elsif _value.respond_to?(meth)

--- a/spec/fixtures/templates/parts_with_args/_box.html.slim
+++ b/spec/fixtures/templates/parts_with_args/_box.html.slim
@@ -1,4 +1,3 @@
 div.box
   h2 = label
   = user[:name]
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,11 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 end
+
+RSpec::Matchers.define :part_including do |data|
+  match { |actual|
+    data.all? { |(key, val)|
+      actual._data[key] == val
+    }
+  }
+end

--- a/spec/unit/null_part_spec.rb
+++ b/spec/unit/null_part_spec.rb
@@ -2,7 +2,7 @@ require 'dry/view/null_part'
 
 RSpec.describe Dry::View::NullPart do
   subject(:part) do
-    Dry::View::NullPart.new(renderer, {user: nil})
+    Dry::View::NullPart.new(renderer, user: nil)
   end
 
   let(:renderer) { double(:renderer) }
@@ -13,16 +13,6 @@ RSpec.describe Dry::View::NullPart do
     end
   end
 
-  describe "#with" do
-    it "builds a new instance with the extra data" do
-      expect(part.with(foo: "bar")).to eq Dry::View::NullPart.new(renderer, {user: nil, foo: "bar"})
-    end
-
-    it "returns self when no data passed" do
-      expect(part.with({})).to eql part
-    end
-  end
-
   describe '#method_missing' do
     context 'template matches' do
       it 'renders template with the _missing suffix' do
@@ -30,22 +20,14 @@ RSpec.describe Dry::View::NullPart do
         expect(renderer).to receive(:render).with('_row_missing.slim', part)
 
         part.row
+
       end
 
       it 'renders template with extra data when a hash is passed' do
         expect(renderer).to receive(:lookup).with('_fields_missing').and_return('_fields_missing.html.slim')
-        expect(renderer).to receive(:render).with('_fields_missing.html.slim', part.with(foo: "bar"))
+        expect(renderer).to receive(:render).with('_fields_missing.html.slim', part_including(foo: "bar"))
 
         part.fields(foo: "bar")
-      end
-
-      it "renders template with extra data (keyed by the template's name) when any other object is passed" do
-        my_thing = Object.new
-
-        expect(renderer).to receive(:lookup).with('_fields_missing').and_return('_fields_missing.html.slim')
-        expect(renderer).to receive(:render).with('_fields_missing.html.slim', part.with(fields: my_thing))
-
-        part.fields(my_thing)
       end
 
       it 'renders a _missing template within another when block is passed' do

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -23,16 +23,6 @@ RSpec.describe Dry::View::Part do
     end
   end
 
-  describe "#with" do
-    it "builds a new value part with the extra data" do
-      expect(part.with(foo: "bar")).to eq Dry::View::ValuePart.new(renderer, foo: "bar")
-    end
-
-    it "returns self when no data passed" do
-      expect(part.with({})).to eql part
-    end
-  end
-
   describe '#method_missing' do
     context 'template matches' do
       it 'renders template' do
@@ -40,22 +30,14 @@ RSpec.describe Dry::View::Part do
         expect(renderer).to receive(:render).with('_row.slim', part)
 
         part.row
+
       end
 
       it 'renders template with extra data when a hash is passed' do
         expect(renderer).to receive(:lookup).with('_fields').and_return('_fields.html.slim')
-        expect(renderer).to receive(:render).with('_fields.html.slim', part.with(foo: "bar"))
+        expect(renderer).to receive(:render).with('_fields.html.slim', part_including(foo: "bar"))
 
         part.fields(foo: "bar")
-      end
-
-      it "renders template with extra data (keyed by the template's name) when any other object is passed" do
-        my_thing = Object.new
-
-        expect(renderer).to receive(:lookup).with('_fields').and_return('_fields.html.slim')
-        expect(renderer).to receive(:render).with('_fields.html.slim', part.with(fields: my_thing))
-
-        part.fields(my_thing)
       end
 
       it 'renders template within another when block is passed' do

--- a/spec/unit/value_part_spec.rb
+++ b/spec/unit/value_part_spec.rb
@@ -32,16 +32,6 @@ RSpec.describe Dry::View::ValuePart do
     end
   end
 
-  describe "#with" do
-    it "builds a new instance with the extra data" do
-      expect(part.with(foo: "bar")).to eq Dry::View::ValuePart.new(renderer, data.merge(foo: "bar"))
-    end
-
-    it "returns self when no data passed" do
-      expect(part.with({})).to eql part
-    end
-  end
-
   describe '#method_missing' do
     context 'template matches' do
       it 'renders template' do
@@ -53,18 +43,9 @@ RSpec.describe Dry::View::ValuePart do
 
       it 'renders template with extra data when a hash is passed' do
         expect(renderer).to receive(:lookup).with('_fields').and_return('_fields.html.slim')
-        expect(renderer).to receive(:render).with('_fields.html.slim', part.with(foo: "bar"))
+        expect(renderer).to receive(:render).with('_fields.html.slim', part_including(foo: "bar"))
 
         part.fields(foo: "bar")
-      end
-
-      it "renders template with extra data (keyed by the template's name) when any other object is passed" do
-        my_thing = Object.new
-
-        expect(renderer).to receive(:lookup).with('_fields').and_return('_fields.html.slim')
-        expect(renderer).to receive(:render).with('_fields.html.slim', part.with(fields: my_thing))
-
-        part.fields(my_thing)
       end
 
       it 'renders template within another when block is passed' do


### PR DESCRIPTION
Use `Part.build` for any additional scope args passed when rendering partials. Do some refactoring to unify the handling of these extra args as well.