### PR TITLE
Rename layout parts and scope options

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -12,6 +12,7 @@ module Dry
       include Dry::Equalizer(:config)
 
       DEFAULT_LAYOUTS_DIR = 'layouts'.freeze
+      LAYOUT_PART_NAME = :layout
 
       extend Dry::Configurable
 
@@ -105,7 +106,7 @@ module Dry
 
       def layout_scope(options, renderer)
         parts = {
-          page: layout_part(renderer, name: :page, value: options.fetch(:scope, scope))
+          LAYOUT_PART_NAME => layout_part(renderer, name: LAYOUT_PART_NAME, value: options.fetch(:scope, scope))
         }
 
         layout_part(renderer, value: parts)

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -18,14 +18,14 @@ module Dry
 
       setting :paths
       setting :layout, false
+      setting :layout_scope
       setting :template
       setting :formats, { html: :erb }
-      setting :scope
 
       attr_reader :config
-      attr_reader :scope
-      attr_reader :layout_dir
       attr_reader :layout
+      attr_reader :default_layout_scope
+      attr_reader :layout_dir
       attr_reader :layout_path
       attr_reader :template_path
       attr_reader :default_format
@@ -78,7 +78,7 @@ module Dry
         @layout = config.layout
         @layout_path = "#{layout_dir}/#{config.layout}"
         @template_path = config.template
-        @scope = config.scope
+        @default_layout_scope = config.layout_scope
         @exposures = self.class.exposures.bind(self)
       end
 
@@ -106,7 +106,7 @@ module Dry
 
       def layout_scope(options, renderer)
         parts = {
-          LAYOUT_PART_NAME => layout_part(renderer, name: LAYOUT_PART_NAME, value: options.fetch(:scope, scope))
+          LAYOUT_PART_NAME => layout_part(renderer, name: LAYOUT_PART_NAME, value: options.fetch(:layout_scope, default_layout_scope))
         }
 
         layout_part(renderer, value: parts)

--- a/spec/fixtures/templates/layouts/app.html.slim
+++ b/spec/fixtures/templates/layouts/app.html.slim
@@ -1,6 +1,6 @@
 doctype html
 html
   head
-    title == page.title
+    title == layout.title
   body
     == yield

--- a/spec/fixtures/templates/layouts/app.txt.erb
+++ b/spec/fixtures/templates/layouts/app.txt.erb
@@ -1,3 +1,3 @@
-# <%= page.title %>
+# <%= layout.title %>
 
 <%= yield %>

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'exposures' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end
@@ -52,7 +52,7 @@ RSpec.describe 'exposures' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end
@@ -80,7 +80,7 @@ RSpec.describe 'exposures' do
       {name: 'Joe', email: 'joe@doe.org'}
     ]
 
-    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">2 users</div></body></html>'
     )
   end
@@ -112,7 +112,7 @@ RSpec.describe 'exposures' do
       {name: 'Joe', email: 'joe@doe.org'}
     ]
 
-    expect(vc.(users: users, scope: scope, locals: {subtitle: 'Users List'})).to eql(
+    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">2 users</div></body></html>'
     )
   end
@@ -144,7 +144,7 @@ RSpec.describe 'exposures' do
       {name: 'Joe', email: 'joe@doe.org'}
     ]
 
-    input = {users: users, scope: scope, locals: {subtitle: 'Users List'}}
+    input = {users: users, layout_scope: scope, locals: {subtitle: 'Users List'}}
 
     expect(vc.(input)).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">COUNT: 2 users</div></body></html>'

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(scope: scope, locals: { subtitle: "Users List", users: users })).to eql(
+    expect(view.(layout_scope: scope, locals: { subtitle: "Users List", users: users })).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end
@@ -39,7 +39,7 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(vc.(scope: scope, locals: { subtitle: "Users List", users: users })).to eql(
+    expect(vc.(layout_scope: scope, locals: { subtitle: "Users List", users: users })).to eql(
       '<h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div>'
     )
   end
@@ -51,7 +51,7 @@ RSpec.describe 'dry-view' do
       end
     end.new
 
-    expect(vc.(scope: scope, locals: {})).to eq(
+    expect(vc.(layout_scope: scope, locals: {})).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><p>This is a view with no locals.</p></body></html>'
     )
   end
@@ -64,7 +64,7 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(scope: scope, locals: { subtitle: 'Users List', users: users }, format: 'txt').strip).to eql(
+    expect(view.(layout_scope: scope, locals: { subtitle: 'Users List', users: users }, format: 'txt').strip).to eql(
       "# dry-view rocks!\n\n## Users List\n\n* Jane (jane@doe.org)\n* Joe (joe@doe.org)"
     )
   end
@@ -81,7 +81,7 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(scope: scope, locals: {subtitle: 'Users List', users: users})).to eq(
+    expect(view.(layout_scope: scope, locals: {subtitle: 'Users List', users: users})).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h1>OVERRIDE</h1><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end
@@ -98,7 +98,7 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(scope: scope, locals: {users: users})).to eq(
+    expect(view.(layout_scope: scope, locals: {users: users})).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><div class="users"><div class="box"><h2>Nombre</h2>Jane</div><div class="box"><h2>Nombre</h2>Joe</div></div></body></html>'
     )
   end
@@ -125,7 +125,7 @@ RSpec.describe 'dry-view' do
     it 'renders within a parent class layout using provided scope' do
       view = child_view.new
 
-      expect(view.(scope: scope, locals: { tasks: [{ title: 'one' }, { title: 'two' }] })).to eql(
+      expect(view.(layout_scope: scope, locals: { tasks: [{ title: 'one' }, { title: 'two' }] })).to eql(
         '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><ol><li>one</li><li>two</li></ol></body></html>'
       )
     end

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dry::View::Controller do
   end
 
   let(:options) do
-    { scope: page, locals: { user: { name: 'Jane' }, header: { title: 'User' } } }
+    { layout_scope: page, locals: { user: { name: 'Jane' }, header: { title: 'User' } } }
   end
 
   let(:renderer) do


### PR DESCRIPTION
Two renames here:

1. Rename the "scope" view controller option to "layout_scope", since it only applies to the layout
2. Rename the view part through which this scope is passed to the layout from "page" to "layout"

Both of these should hopefully increase clarity. In the case of (1), the option's intended use is clearer, and in the case of (2) , we don't use the notion of a "page" anywhere in dry-view, so simply calling the view part "layout" makes more sense, and it works pretty well from inside the template code, since "layout" seems more fitting inside an actual layout template.

Resolves #8