### PR TITLE
Make a shared context available across layouts, templates and partials

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -103,13 +103,13 @@ module Dry
       end
 
       def layout_scope(renderer, options)
-        context = options.fetch(:context) { self.class.config.context }
+        context = options.fetch(:context) { config.context }
 
         Scope.new(renderer.chdir(layout_dir), {}, context)
       end
 
       def template_scope(renderer, options)
-        context = options.fetch(:context) { self.class.config.context }
+        context = options.fetch(:context) { config.context }
 
         Scope.new(renderer.chdir(template_path), locals(options), context)
       end

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -12,19 +12,18 @@ module Dry
       include Dry::Equalizer(:config)
 
       DEFAULT_LAYOUTS_DIR = 'layouts'.freeze
-      LAYOUT_PART_NAME = :layout
+      DEFAULT_CONTEXT = Object.new.freeze
 
       extend Dry::Configurable
 
       setting :paths
       setting :layout, false
-      setting :layout_scope
+      setting :context, DEFAULT_CONTEXT
       setting :template
       setting :formats, { html: :erb }
 
       attr_reader :config
       attr_reader :layout
-      attr_reader :default_layout_scope
       attr_reader :layout_dir
       attr_reader :layout_path
       attr_reader :template_path
@@ -78,7 +77,6 @@ module Dry
         @layout = config.layout
         @layout_path = "#{layout_dir}/#{config.layout}"
         @template_path = config.template
-        @default_layout_scope = config.layout_scope
         @exposures = self.class.exposures.bind(self)
       end
 
@@ -105,13 +103,15 @@ module Dry
       end
 
       def layout_scope(renderer, options)
-        scope = {LAYOUT_PART_NAME => options.fetch(:layout_scope, default_layout_scope)}
+        context = options.fetch(:context) { self.class.config.context }
 
-        Scope.new(renderer.chdir(layout_dir), scope)
+        Scope.new(renderer.chdir(layout_dir), {}, context)
       end
 
       def template_scope(renderer, options)
-        Scope.new(renderer.chdir(template_path), locals(options))
+        context = options.fetch(:context) { self.class.config.context }
+
+        Scope.new(renderer.chdir(template_path), locals(options), context)
       end
     end
   end

--- a/spec/fixtures/templates/layouts/app.html.slim
+++ b/spec/fixtures/templates/layouts/app.html.slim
@@ -1,6 +1,6 @@
 doctype html
 html
   head
-    title == layout.title
+    title == title
   body
     == yield

--- a/spec/fixtures/templates/layouts/app.txt.erb
+++ b/spec/fixtures/templates/layouts/app.txt.erb
@@ -1,3 +1,3 @@
-# <%= layout.title %>
+# <%= title %>
 
 <%= yield %>

--- a/spec/fixtures/templates/users.html.slim
+++ b/spec/fixtures/templates/users.html.slim
@@ -3,3 +3,5 @@ h2 = subtitle
 .users
   == index_table do
     == tbody
+
+img src=assets["mindblown"]

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'exposures' do
-  let(:scope) { Struct.new(:title).new('dry-view rocks!') }
+  let(:context) { Struct.new(:title, :assets).new('dry-view rocks!', -> input { "#{input}.jpg" }) }
 
   it 'uses exposures to build view locals' do
     vc = Class.new(Dry::View::Controller) do
@@ -22,8 +22,8 @@ RSpec.describe 'exposures' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
-      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    expect(vc.(users: users, context: context, locals: {subtitle: 'Users List'})).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" /></body></html>'
     )
   end
 
@@ -52,8 +52,8 @@ RSpec.describe 'exposures' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
-      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    expect(vc.(users: users, context: context, locals: {subtitle: 'Users List'})).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>JANE</td><td>jane@doe.org</td></tr><tr><td>JOE</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" /></body></html>'
     )
   end
 
@@ -80,7 +80,7 @@ RSpec.describe 'exposures' do
       {name: 'Joe', email: 'joe@doe.org'}
     ]
 
-    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
+    expect(vc.(users: users, context: context, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">2 users</div></body></html>'
     )
   end
@@ -112,7 +112,7 @@ RSpec.describe 'exposures' do
       {name: 'Joe', email: 'joe@doe.org'}
     ]
 
-    expect(vc.(users: users, layout_scope: scope, locals: {subtitle: 'Users List'})).to eql(
+    expect(vc.(users: users, context: context, locals: {subtitle: 'Users List'})).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">2 users</div></body></html>'
     )
   end
@@ -144,7 +144,7 @@ RSpec.describe 'exposures' do
       {name: 'Joe', email: 'joe@doe.org'}
     ]
 
-    input = {users: users, layout_scope: scope, locals: {subtitle: 'Users List'}}
+    input = {users: users, context: context, locals: {subtitle: 'Users List'}}
 
     expect(vc.(input)).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><ul><li>Jane (jane@doe.org)</li><li>Joe (joe@doe.org)</li></ul><div class="count">COUNT: 2 users</div></body></html>'

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -10,11 +10,11 @@ RSpec.describe 'dry-view' do
     end
   end
 
-  let(:scope) do
-    Struct.new(:title).new('dry-view rocks!')
+  let(:context) do
+    Struct.new(:title, :assets).new('dry-view rocks!', -> input { "#{input}.jpg" })
   end
 
-  it 'renders within a layout using provided scope' do
+  it 'renders within a layout and makes the provided context available everywhere' do
     view = view_class.new
 
     users = [
@@ -22,8 +22,8 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(layout_scope: scope, locals: { subtitle: "Users List", users: users })).to eql(
-      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
+    expect(view.(context: context, locals: { subtitle: "Users List", users: users })).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" /></body></html>'
     )
   end
 
@@ -39,8 +39,8 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(vc.(layout_scope: scope, locals: { subtitle: "Users List", users: users })).to eql(
-      '<h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div>'
+    expect(vc.(context: context, locals: { subtitle: "Users List", users: users })).to eql(
+      '<h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" />'
     )
   end
 
@@ -51,7 +51,7 @@ RSpec.describe 'dry-view' do
       end
     end.new
 
-    expect(vc.(layout_scope: scope, locals: {})).to eq(
+    expect(vc.(context: context, locals: {})).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><p>This is a view with no locals.</p></body></html>'
     )
   end
@@ -64,7 +64,7 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(layout_scope: scope, locals: { subtitle: 'Users List', users: users }, format: 'txt').strip).to eql(
+    expect(view.(context: context, locals: { subtitle: 'Users List', users: users }, format: 'txt').strip).to eql(
       "# dry-view rocks!\n\n## Users List\n\n* Jane (jane@doe.org)\n* Joe (joe@doe.org)"
     )
   end
@@ -81,12 +81,12 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(layout_scope: scope, locals: {subtitle: 'Users List', users: users})).to eq(
+    expect(view.(context: context, locals: {subtitle: 'Users List', users: users})).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h1>OVERRIDE</h1><h2>Users List</h2><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end
 
-  it 'renders a view that passes arguments to it parts' do
+  it 'renders a view that passes arguments to partials' do
     view = Class.new(view_class) do
       configure do |config|
         config.template = 'parts_with_args'
@@ -98,7 +98,7 @@ RSpec.describe 'dry-view' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(view.(layout_scope: scope, locals: {users: users})).to eq(
+    expect(view.(context: context, locals: {users: users})).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><div class="users"><div class="box"><h2>Nombre</h2>Jane</div><div class="box"><h2>Nombre</h2>Joe</div></div></body></html>'
     )
   end
@@ -122,10 +122,10 @@ RSpec.describe 'dry-view' do
       end
     end
 
-    it 'renders within a parent class layout using provided scope' do
+    it 'renders within a parent class layout using provided context' do
       view = child_view.new
 
-      expect(view.(layout_scope: scope, locals: { tasks: [{ title: 'one' }, { title: 'two' }] })).to eql(
+      expect(view.(context: context, locals: { tasks: [{ title: 'one' }, { title: 'two' }] })).to eql(
         '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><ol><li>one</li><li>two</li></ol></body></html>'
       )
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 if RUBY_ENGINE == 'ruby'
   require 'simplecov'
-  SimpleCov.start
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
 end
 
 begin

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dry::View::Controller do
   end
 
   let(:options) do
-    { layout_scope: page, locals: { user: { name: 'Jane' }, header: { title: 'User' } } }
+    { context: page, locals: { user: { name: 'Jane' }, header: { title: 'User' } } }
   end
 
   let(:renderer) do


### PR DESCRIPTION
This removes the `layout_scope` and replaces it with a `context`. The context is an object that is available in the scope for _all templates_ (layouts, templates and partials), and is looked up after any data otherwise available on that scope.

This makes it possible to set up a context object with common things that you need across all parts of your app's templates, like CSRF tags, asset URL generators, the current_user, etc.