### PR TITLE
Resolve methods from scope in order of data, context, partials

### DIFF
--- a/lib/dry/view/scope.rb
+++ b/lib/dry/view/scope.rb
@@ -22,14 +22,12 @@ module Dry
       private
 
       def method_missing(name, *args, &block)
-        template_path = _template?(name)
-
-        if template_path
-          _render(template_path, *args, &block)
-        elsif _data.key?(name)
+        if _data.key?(name)
           _data[name]
         elsif _context.respond_to?(name)
           _context.public_send(name, *args, &block)
+        elsif (template_path = _template?(name))
+          _render(template_path, *args, &block)
         else
           super
         end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -6,29 +6,75 @@ RSpec.describe Dry::View::Scope do
   }
 
   let(:renderer) { double("renderer") }
-  let(:data) { {user_name: "Jane Doe"} }
-  let(:context) {
-    Class.new do
-      def asset(name)
-        "#{name}.jpg"
-      end
-
-      def current_user
-        "current user"
-      end
-    end.new
-  }
+  let(:data) { {} }
+  let(:context) { Object.new }
 
   describe "missing method behavior" do
     before do
       allow(renderer).to receive(:lookup).and_return false
+      allow(renderer).to receive(:render)
+    end
+
+    describe "accessing data" do
+      let(:data) { {user_name: "Jane Doe", current_user: "data's current_user"} }
+      let(:context) {
+        Class.new do
+          def current_user
+            "context's current_user"
+          end
+        end.new
+      }
+
+      before do
+        allow(renderer).to receive(:lookup).with('_current_user').and_return '_current_user.html.slim'
+      end
+
+      it "returns matching scope data" do
+        expect(scope.user_name).to eq "Jane Doe"
+      end
+
+      it "raises an error when no data matches" do
+        expect { scope.missing }.to raise_error(NoMethodError)
+      end
+
+      it "returns data in favour of both context methods and partials" do
+        expect(scope.current_user).to eq "data's current_user"
+      end
+    end
+
+    describe "accessing context" do
+      let(:context) {
+        Class.new do
+          def current_user
+            "context's current_user"
+          end
+
+          def asset(name)
+            "#{name}.jpg"
+          end
+        end.new
+      }
+
+      before do
+        allow(renderer).to receive(:lookup).with('_current_user').and_return '_current_user.html.slim'
+      end
+
+      it "forwards to matching methods on the context in favour of partials" do
+        expect(scope.current_user).to eq "context's current_user"
+      end
+
+      it "allows arguments to be passed to those methods as normal" do
+        expect(scope.asset("mindblown")).to eq "mindblown.jpg"
+      end
+
+      it "raises an error when no method matches" do
+        expect { scope.missing }.to raise_error(NoMethodError)
+      end
     end
 
     describe "rendering" do
       before do
         allow(renderer).to receive(:lookup).with('_list').and_return '_list.html.slim'
-        allow(renderer).to receive(:lookup).with('_user_name').and_return '_user_name.html.slim'
-        allow(renderer).to receive(:render)
       end
 
       it "renders a matching partial using the existing scope" do
@@ -44,37 +90,8 @@ RSpec.describe Dry::View::Scope do
           .with('_list.html.slim', described_class.new(renderer, something: 'else'))
       end
 
-      it "renders a partial in favour of a matching data value" do
-        scope.user_name
-
-        expect(renderer).to have_received(:render).with('_user_name.html.slim', scope)
-      end
-
       it "raises an error if arguments passed are not a hash" do
         expect { scope.list('hi') }.to raise_error(ArgumentError)
-      end
-    end
-
-    describe "accessing data" do
-      let(:data) { {user_name: "Jane Doe", current_user: "provided by data"} }
-
-      it "returns matching scope data" do
-        expect(scope.user_name).to eq "Jane Doe"
-      end
-
-      it "raises an error when no data matches" do
-        expect { scope.missing }.to raise_error(NoMethodError)
-      end
-
-      it "returns data in favour of context methods" do
-        expect(scope.current_user).to eq "provided by data"
-      end
-    end
-
-    describe "accessing context" do
-      it "forwards to matching methods on the context" do
-        expect(scope.current_user).to eq "current user"
-        expect(scope.asset("mindblown")).to eq "mindblown.jpg"
       end
     end
   end


### PR DESCRIPTION
This reduces the risk of partials with names conflicting with data causing problems.