### PR TITLE
Use keyword args for accepting input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,13 @@ rvm:
   - 2.3.3
   - 2.2.6
   - 2.1.10
-  - jruby-9.1.5.0
+  - jruby-9.1.6.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'
+matrix:
+  allow_failures:
+    - rvm: jruby-9.1.6.0
 notifications:
   email: false
   webhooks:


### PR DESCRIPTION
This allows us to remove some of the “special” options (`format`, `context`, and `locals`) before they get passed to the exposures to build up the final locals hash to pass to the scope.