### PR TITLE
Make the view controller instance available to exposure blocks

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -48,7 +48,7 @@ module Dry
           exposures.add(names.first, block, **options)
         else
           names.each do |name|
-            exposures.add(name, nil, **options)
+            exposures.add(name, **options)
           end
         end
       end


### PR DESCRIPTION
This is important for accessing instance data in cases where there are dependencies injected into the view controller, e.g.

```ruby
class MyView < Dry::View::Controller
  include MyApp::Import[repo: "repositories.users"]

  expose :users do
    repo.listing
  end
end
```