### PR TITLE
Make all partial rendering explicit via `Scope#render`

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -92,11 +92,11 @@ module Dry
       end
 
       def layout_scope(renderer, context: config.context, **)
-        scope(renderer.chdir(layout_dir), EMPTY_LOCALS, context)
+        scope(renderer, EMPTY_LOCALS, context)
       end
 
       def template_scope(renderer, context: config.context, **input)
-        scope(renderer.chdir(template_path), locals(**input), context)
+        scope(renderer, locals(**input), context)
       end
 
       def scope(renderer, locals, context)

--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -13,7 +13,9 @@ module Dry
       end
 
       def lookup(name, format)
-        template?(name, format) || template?("shared/#{name}", format) || !root? && chdir('..').lookup(name, format)
+        # Search for a template using a wildcard for the engine extension
+        glob = dir.join("#{name}.#{format}.*")
+        Dir[glob].first
       end
 
       def chdir(dirname)
@@ -22,18 +24,6 @@ module Dry
 
       def to_s
         dir
-      end
-
-      private
-
-      def root?
-        dir == root
-      end
-
-      # Search for a template using a wildcard for the engine extension
-      def template?(name, format)
-        glob = dir.join("#{name}.#{format}.*")
-        Dir[glob].first
       end
     end
   end

--- a/lib/dry/view/scope.rb
+++ b/lib/dry/view/scope.rb
@@ -15,6 +15,13 @@ module Dry
         @_context = context
       end
 
+      def render(name, *args, &block)
+        path = _renderer.lookup(_partial_name(name))
+        raise "template +#{path}+ not found" unless path
+
+        _renderer.render(path, _render_args(*args), &block)
+      end
+
       def respond_to_missing?(name, include_private = false)
         _template?(name) || _data.key?(name) || _context.respond_to?(name)
       end
@@ -26,19 +33,16 @@ module Dry
           _data[name]
         elsif _context.respond_to?(name)
           _context.public_send(name, *args, &block)
-        elsif (template_path = _template?(name))
-          _render(template_path, *args, &block)
         else
           super
         end
       end
 
-      def _template?(name)
-        _renderer.lookup("_#{name}")
-      end
+      def _partial_name(name)
+        parts = name.split("/")
+        parts[-1] = "_#{parts[-1]}"
 
-      def _render(path, *args, &block)
-        _renderer.render(path, _render_args(*args), &block)
+        parts.join("/")
       end
 
       def _render_args(*args)

--- a/spec/fixtures/templates/parts_with_args.html.slim
+++ b/spec/fixtures/templates/parts_with_args.html.slim
@@ -1,3 +1,3 @@
 .users
   - users.each do |user|
-    == box user: user, label: "Nombre"
+    == render "parts_with_args/box", user: user, label: "Nombre"

--- a/spec/fixtures/templates/users.html.slim
+++ b/spec/fixtures/templates/users.html.slim
@@ -1,5 +1,5 @@
 .users
-  == index_table do
-    == tbody
+  == render "shared/index_table" do
+    == render "users/tbody"
 
 img src=assets["mindblown"]

--- a/spec/fixtures/templates/users/_tbody.html.slim
+++ b/spec/fixtures/templates/users/_tbody.html.slim
@@ -1,5 +1,5 @@
 tbody
   - users.each do |user|
-    == row do
+    == render "users/row" do
       td = user[:name]
       td = user[:email]

--- a/spec/fixtures/templates_override/users.html.slim
+++ b/spec/fixtures/templates_override/users.html.slim
@@ -1,5 +1,5 @@
 h1 OVERRIDE
 
 .users
-  == index_table do
-    == tbody
+  == render "shared/index_table" do
+    == render "users/tbody"

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe Dry::View::Renderer do
       expect(renderer.('hello', scope)).to eql('<h1>Hello</h1>')
     end
 
-    it 'looks up shared template in current dir' do
-      expect(renderer.('_shared_hello', scope)).to eql('<h1>Hello</h1>')
-    end
-
-    it 'looks up shared template in upper dir' do
-      expect(renderer.chdir('greetings').('_shared_hello', scope)).to eql('<h1>Hello</h1>')
-    end
-
     it 'raises error when template was not found' do
       expect {
         renderer.('not_found', scope)

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -78,20 +78,20 @@ RSpec.describe Dry::View::Scope do
       end
 
       it "renders a matching partial using the existing scope" do
-        scope.list
+        scope.render 'list'
 
         expect(renderer).to have_received(:render).with('_list.html.slim', scope)
       end
 
       it "renders a matching partial using a scope based on arguments passed" do
-        scope.list(something: 'else')
+        scope.render 'list', something: 'else'
 
         expect(renderer).to have_received(:render)
           .with('_list.html.slim', described_class.new(renderer, something: 'else'))
       end
 
       it "raises an error if arguments passed are not a hash" do
-        expect { scope.list('hi') }.to raise_error(ArgumentError)
+        expect { scope.render 'list', 'hi' }.to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
As part of making the view scopes more predictable and easier to understand (and with a general view of favouring explicit over implicit behaviour), I've made it so that partial rendering is now done in the templates via a call to `#render`, rather than relying on method_missing behavior.

So now, you'd render a partial like this:

```slim
== render "profile_box", user: user
```

Instead of like this:

```slim
== profile_box user: user
```

This change also makes all the template paths explicit, rather than using a lookup algorithm that searches in specific dirs ("shared/" and "<template_name>/") and chdirs upwards until it finds a match.

I'd like to make this part of 0.3.0, along with some other changes to make it so that application authors have more control over their view scopes.