### PR TITLE
Support :each_as option for specifying part class for array members

### DIFF
--- a/lib/dry/view/decorator.rb
+++ b/lib/dry/view/decorator.rb
@@ -12,9 +12,10 @@ module Dry
 
         if value.respond_to?(:to_ary)
           singular_name = Dry::Core::Inflector.singularize(name).to_sym
+          singular_options = singularize_options(options)
 
           arr = value.to_ary.map { |obj|
-            call(singular_name, obj, renderer: renderer, context: context, **options)
+            call(singular_name, obj, renderer: renderer, context: context, **singular_options)
           }
 
           klass.new(name: name, value: arr, renderer: renderer, context: context)
@@ -26,6 +27,15 @@ module Dry
       # @api public
       def part_class(name, value, **options)
         options.fetch(:as) { Part }
+      end
+
+      private
+
+      # @api private
+      def singularize_options(**options)
+        options = options.dup
+        options[:as] = options.delete(:each_as) if options.key?(:each_as)
+        options
       end
     end
   end

--- a/spec/fixtures/templates/decorated_parts.html.slim
+++ b/spec/fixtures/templates/decorated_parts.html.slim
@@ -1,2 +1,4 @@
+- customs.each do |custom|
+  p = custom
 p = custom
 p = ordinary

--- a/spec/integration/decorator_spec.rb
+++ b/spec/integration/decorator_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'decorator' do
   end
 
   describe 'default decorator' do
-    it 'supports wrapping in custom part classes provided to exposure :as option' do
+    it 'supports wrapping in custom part classes provided to exposure :as and :each_as options' do
       vc = Class.new(Dry::View::Controller) do
         configure do |config|
           config.paths = SPEC_ROOT.join('fixtures/templates')
@@ -18,12 +18,13 @@ RSpec.describe 'decorator' do
           config.template = 'decorated_parts'
         end
 
+        expose :customs, each_as: Test::CustomPart
         expose :custom, as: Test::CustomPart
         expose :ordinary
       end.new
 
-      expect(vc.(custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
-        '<p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
+      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
+        '<p>Custom part wrapping many things</p><p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
       )
     end
   end
@@ -44,11 +45,11 @@ RSpec.describe 'decorator' do
           config.template = 'decorated_parts'
         end
 
-        expose :custom, :ordinary
+        expose :customs, :custom, :ordinary
       end.new
 
-      expect(vc.(custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
-        '<p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
+      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
+        '<p>Custom part wrapping many things</p><p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
       )
     end
   end


### PR DESCRIPTION
Our standard decorator handles arrays of objects in a special way, decorating each member of the array as well as the array itself. Given we support specifying an `as:` option on exposures to provide a custom part class, we should also support providing a custom part class for array members. This PR implements this using the `each_as:` option.

This feels like the last thing we need before we can release the decorator and parts feature.