### PR TITLE
Replace :each_as exposure option with hash argument form for :as option

### DIFF
--- a/lib/dry/view/decorator.rb
+++ b/lib/dry/view/decorator.rb
@@ -26,14 +26,18 @@ module Dry
 
       # @api public
       def part_class(name, value, **options)
-        options.fetch(:as) { Part }
+        if options[:as].is_a?(Hash)
+          options[:as].keys.first
+        else
+          options.fetch(:as) { Part }
+        end
       end
 
       private
 
       # @api private
       def singularize_options(**options)
-        options[:as] = options.delete(:each_as) if options.key?(:each_as)
+        options[:as] = options[:as].values.first if options[:as].is_a?(Hash)
         options
       end
     end

--- a/spec/integration/decorator_spec.rb
+++ b/spec/integration/decorator_spec.rb
@@ -6,11 +6,17 @@ RSpec.describe 'decorator' do
           "Custom part wrapping #{_value}"
         end
       end
+
+      class CustomArrayPart < Dry::View::Part
+        def each(&block)
+          (_value * 2).each(&block)
+        end
+      end
     end
   end
 
   describe 'default decorator' do
-    it 'supports wrapping in custom part classes provided to exposure :as and :each_as options' do
+    it 'supports wrapping array memebers in custom part classes provided to exposure :as option' do
       vc = Class.new(Dry::View::Controller) do
         configure do |config|
           config.paths = SPEC_ROOT.join('fixtures/templates')
@@ -18,13 +24,31 @@ RSpec.describe 'decorator' do
           config.template = 'decorated_parts'
         end
 
-        expose :customs, each_as: Test::CustomPart
+        expose :customs, as: Test::CustomPart
         expose :custom, as: Test::CustomPart
         expose :ordinary
       end.new
 
       expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
         '<p>Custom part wrapping many things</p><p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
+      )
+    end
+
+    it 'supports wrapping an array and its members in custom part classes provided to exposure :as option as a hash' do
+      vc = Class.new(Dry::View::Controller) do
+        configure do |config|
+          config.paths = SPEC_ROOT.join('fixtures/templates')
+          config.layout = nil
+          config.template = 'decorated_parts'
+        end
+
+        expose :customs, as: {Test::CustomArrayPart => Test::CustomPart}
+        expose :custom, as: Test::CustomPart
+        expose :ordinary
+      end.new
+
+      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
+        '<p>Custom part wrapping many things</p><p>Custom part wrapping many things</p><p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
       )
     end
   end


### PR DESCRIPTION
In response to the comments on #36 (thanks @solnic!), the `:as` exposure option now takes 2 forms for decorating arrays:

- `expose :things, as: MyPart` – decorate each _member_ of the array with `MyPart`
- `expose :things, as: {MyArrayPart => MyPart}` – decorate the array itself with `MyArrayPart` and each member with `MyPart`

This means the default dry-view decorator can now do everything it needs with a single `:as` option on exposures, and we can remove the `:each_as` option I introduced in #36. A nicer API! Thanks all.

Last thing I want to do before we release all of this is add a few API docs as well as updating the dry-rb.org docs to reflect this new `:as` behaviour.