### PR TITLE
Display useful error message when partial is not found

### DIFF
--- a/lib/dry/view/scope.rb
+++ b/lib/dry/view/scope.rb
@@ -5,6 +5,8 @@ module Dry
     class Scope
       include Dry::Equalizer(:_locals, :_context, :_renderer)
 
+      PartialNotFoundError = Class.new(StandardError)
+
       attr_reader :_locals
       attr_reader :_context
       attr_reader :_renderer
@@ -16,11 +18,18 @@ module Dry
       end
 
       def render(partial_name, **locals, &block)
-        _renderer.render(
-          __partial(partial_name),
-          __render_scope(**locals),
-          &block
-        )
+        path = __partial(partial_name)
+
+        if path
+          _renderer.render(
+            path,
+            __render_scope(**locals),
+            &block
+            )
+        else
+          msg = "Partial #{partial_name.inspect} could not be found in any path or shared folder"
+          raise PartialNotFoundError, msg
+        end
       end
 
       private

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -6,21 +6,36 @@ RSpec.describe Dry::View::Scope do
   let(:renderer) { double('renderer') }
 
   describe '#render' do
-    before do
-      allow(renderer).to receive(:lookup).with('_info').and_return '_info.html.erb'
-      allow(renderer).to receive(:render)
+    context 'partial found' do
+      before do
+        allow(renderer).to receive(:lookup).with('_info').and_return '_info.html.erb'
+        allow(renderer).to receive(:render)
+      end
+
+      it 'renders a partial with itself as the scope' do
+        scope.render(:info)
+        expect(renderer).to have_received(:render).with('_info.html.erb', scope)
+      end
+
+      it 'renders a partial with provided locals' do
+        scope_with_locals = described_class.new(renderer: renderer, context: context, locals: {foo: 'bar'})
+
+        scope.render(:info, foo: 'bar')
+        expect(renderer).to have_received(:render).with('_info.html.erb', scope_with_locals)
+      end
     end
 
-    it 'renders a partial with itself as the scope' do
-      scope.render(:info)
-      expect(renderer).to have_received(:render).with('_info.html.erb', scope)
-    end
+    context 'partial not found' do
+      before do
+        allow(renderer).to receive(:lookup).with('_info').and_return false
+        allow(renderer).to receive(:render)
+      end
 
-    it 'renders a partial with provided locals' do
-      scope_with_locals = described_class.new(renderer: renderer, context: context, locals: {foo: 'bar'})
-
-      scope.render(:info, foo: 'bar')
-      expect(renderer).to have_received(:render).with('_info.html.erb', scope_with_locals)
+      it 'raises error when partial was not found' do
+        expect {
+          scope.render(:info)
+        }.to raise_error(Dry::View::Scope::PartialNotFoundError, /info/)
+      end
     end
   end
 


### PR DESCRIPTION
This fixed #39 

Raises `PartialNotFoundError ` if lookup returns false