### PR TITLE
Fix keywords usage

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -51,17 +51,17 @@ module Dry
       # @api public
       def self.expose(*names, **options, &block)
         if names.length == 1
-          exposures.add(names.first, block, **options)
+          exposures.add(names.first, block, options)
         else
           names.each do |name|
-            exposures.add(name, **options)
+            exposures.add(name, options)
           end
         end
       end
 
       # @api public
       def self.private_expose(*names, **options, &block)
-        expose(*names, **options.merge(private: true), &block)
+        expose(*names, **options, private: true, &block)
       end
 
       # @api private
@@ -82,7 +82,7 @@ module Dry
       def call(format: config.default_format, context: config.context, **input)
         renderer = self.class.renderer(format)
 
-        template_content = renderer.(template_path, template_scope(renderer, context, **input))
+        template_content = renderer.(template_path, template_scope(renderer, context, input))
 
         return template_content unless layout?
 
@@ -107,7 +107,7 @@ module Dry
       end
 
       def template_scope(renderer, context, **input)
-        scope(renderer.chdir(template_path), context, locals(**input))
+        scope(renderer.chdir(template_path), context, locals(input))
       end
 
       def scope(renderer, context, locals = EMPTY_LOCALS)

--- a/lib/dry/view/decorator.rb
+++ b/lib/dry/view/decorator.rb
@@ -8,7 +8,7 @@ module Dry
 
       # @api public
       def call(name, value, renderer:, context:, **options)
-        klass = part_class(name, value, **options)
+        klass = part_class(name, value, options)
 
         if value.respond_to?(:to_ary)
           singular_name = Dry::Core::Inflector.singularize(name).to_sym

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -20,7 +20,7 @@ module Dry
       end
 
       def bind(obj)
-        self.class.new(name, proc, obj, **options)
+        self.class.new(name, proc, obj, options)
       end
 
       def dependencies

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -21,7 +21,7 @@ module Dry
       end
 
       def add(name, proc = nil, **options)
-        exposures[name] = Exposure.new(name, proc, **options)
+        exposures[name] = Exposure.new(name, proc, options)
       end
 
       def bind(obj)

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -30,7 +30,7 @@ module Dry
       def _render(partial_name, as: _name, **locals, &block)
         _renderer.render(
           _partial(partial_name),
-          _render_scope(as, **locals),
+          _render_scope(as, locals),
           &block
         )
       end

--- a/lib/dry/view/scope.rb
+++ b/lib/dry/view/scope.rb
@@ -23,7 +23,7 @@ module Dry
         if path
           _renderer.render(
             path,
-            __render_scope(**locals),
+            __render_scope(locals),
             &block
             )
         else


### PR DESCRIPTION
Have a look 😄 

```ruby
require "benchmark/ips"

def foo(seq, kw)
end

def fast
  kw = { a: 1, b: 2, c: 3 }

  foo(1, kw)
end

def slow
  kw = { a: 1, b: 2, c: 3 }

  foo(1, **kw)
end

Benchmark.ips do |x|
  x.report("fast code description") { fast }
  x.report("slow code description") { slow }
  x.compare!
end

__END__

Warming up --------------------------------------
fast code description
                       108.311k i/100ms
slow code description
                        50.038k i/100ms
Calculating -------------------------------------
fast code description
                          1.596M (± 3.7%) i/s -      8.015M in   5.028700s
slow code description
                        576.682k (± 3.4%) i/s -      2.902M in   5.038684s

Comparison:
fast code description:  1596244.7 i/s
slow code description:   576682.4 i/s - 2.77x  slower
```