### PR TITLE
Allow setting default values for exposure

### DIFF
--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -53,11 +53,12 @@ module Dry
       end
 
       def call(input, locals = {})
-        if proc
-          call_proc(input, locals)
-        else
-          input[name]
-        end
+        value = if proc
+                  call_proc(input, locals)
+                else
+                  input[name]
+                end
+        value || default_value
       end
 
       private

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -53,12 +53,11 @@ module Dry
       end
 
       def call(input, locals = {})
-        value = if proc
-                  call_proc(input, locals)
-                else
-                  input[name]
-                end
-        value || default_value
+        if proc
+          call_proc(input, locals)
+        else
+          input.fetch(name) { default_value }
+        end
       end
 
       private

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -48,6 +48,10 @@ module Dry
         options.fetch(:private) { false }
       end
 
+      def default_value
+        options[:default]
+      end
+
       def call(input, locals = {})
         if proc
           call_proc(input, locals)

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -34,7 +34,10 @@ module Dry
 
       def locals(input)
         tsort.each_with_object({}) { |name, memo|
-          memo[name] = self[name].(input, memo) if exposures.key?(name)
+          if exposures.key?(name)
+            value = self[name].(input, memo) || self[name].default_value
+            memo[name] = value
+          end
         }.each_with_object({}) { |(name, val), memo|
           memo[name] = val unless self[name].private?
         }

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -34,10 +34,7 @@ module Dry
 
       def locals(input)
         tsort.each_with_object({}) { |name, memo|
-          if exposures.key?(name)
-            value = self[name].(input, memo) || self[name].default_value
-            memo[name] = value
-          end
+          memo[name] = self[name].(input, memo) if exposures.key?(name)
         }.each_with_object({}) { |(name, val), memo|
           memo[name] = val unless self[name].private?
         }

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -129,6 +129,23 @@ RSpec.describe 'exposures' do
     )
   end
 
+  it 'having default values but passing nil as value for exposure' do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'greeting'
+        config.default_format = :html
+      end
+
+      expose :greeting, default: 'Hello Dry-rb'
+    end.new
+
+    expect(vc.(greeting: nil, context: context)).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><p></p></body></html>'
+    )
+  end
+
   it 'allows exposures to depend on each other' do
     vc = Class.new(Dry::View::Controller) do
       configure do |config|

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -112,6 +112,23 @@ RSpec.describe 'exposures' do
     )
   end
 
+  it 'using default values' do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'users'
+        config.default_format = :html
+      end
+
+      expose :users, default: [{name: 'John', email: 'john@william.org'}]
+    end.new
+
+    expect(vc.(context: context)).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><div class="users"><table><tbody><tr><td>John</td><td>john@william.org</td></tr></tbody></table></div><img src="mindblown.jpg" /></body></html>'
+    )
+  end
+
   it 'allows exposures to depend on each other' do
     vc = Class.new(Dry::View::Controller) do
       configure do |config|

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe Dry::View::Exposure do
-  subject(:exposure) { described_class.new(:hello, proc, object) }
+  subject(:exposure) { described_class.new(:hello, proc, object, **options) }
 
   let(:proc) { -> input { "hi" } }
   let(:object) { nil }
+  let(:options) { {} }
 
   describe "initialization and attributes" do
     describe "#name" do
@@ -152,6 +153,34 @@ RSpec.describe Dry::View::Exposure do
 
       it "sends the input and dependency values to the proc" do
         expect(exposure.(input, locals)).to eq "Hola, Jane"
+      end
+    end
+
+    context "Default value" do
+      let(:options) { { default: "John" } }
+
+      context "use default value" do
+        let(:proc) { nil }
+
+        it "use the default value" do
+          expect(exposure.({})).to eq "John"
+        end
+      end
+
+      context "use input value instead of default" do
+        let(:proc) { nil }
+
+        it "use the default value" do
+          expect(exposure.({hello: "Jane"})).to eq "Jane"
+        end
+      end
+
+      context "use input value over default even when input is nil" do
+        let(:proc) { nil }
+
+        it "use the default value" do
+          expect(exposure.({hello: nil})).to eq nil
+        end
       end
     end
 

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe Dry::View::Exposure do
         expect(described_class.new(:hello, private: true)).to be_private
       end
     end
+
+    describe "#default_value" do
+      it "is nil by default" do
+        expect(exposure.default_value).to be_nil
+      end
+
+      it "can be set on initialization" do
+        exposuse = described_class.new(:hello, default: 'Hi !')
+        expect(exposuse.default_value).to eq('Hi !')
+      end
+    end
   end
 
   describe "#bind" do

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe Dry::View::Exposures do
       expect(locals).to eq(:name=>"William")
     end
 
+    it "returns values from arguments even when value is nil" do
+      exposures.add(:name, default: 'John')
+      locals = exposures.locals(name: nil)
+
+      expect(locals).to eq(:name=>nil)
+    end
+
     it "returns value from proc" do
       exposures.add(:name, -> name: { name.upcase }, default: 'John')
       locals = exposures.locals(name: 'William')

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Dry::View::Exposures do
     end
 
     it "returns value from proc" do
-      exposures.add(:name, -> input { input.fetch(:name).upcase }, default: 'John')
+      exposures.add(:name, -> name: { name.upcase }, default: 'John')
       locals = exposures.locals(name: 'William')
 
       expect(locals).to eq(:name=>"WILLIAM")

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -60,4 +60,27 @@ RSpec.describe Dry::View::Exposures do
       expect(locals).not_to include(:hidden)
     end
   end
+
+  describe "#locals default value" do
+    it "returns 'default_value' from exposure" do
+      exposures.add(:name, default: 'John')
+      locals = exposures.locals({})
+
+      expect(locals).to eq(:name=>"John")
+    end
+
+    it "returns values from arguments" do
+      exposures.add(:name, default: 'John')
+      locals = exposures.locals(name: 'William')
+
+      expect(locals).to eq(:name=>"William")
+    end
+
+    it "returns value from proc" do
+      exposures.add(:name, -> input { input.fetch(:name).upcase }, default: 'John')
+      locals = exposures.locals(name: 'William')
+
+      expect(locals).to eq(:name=>"WILLIAM")
+    end
+  end
 end


### PR DESCRIPTION
This will allow setting a default value for exposure.

The change is motivated because on a `dry-web-roda` project I'm working I have to pass errors to a form view to display them, but if I do not have errors I'm forced to pass them as an empty array from my routes.

```ruby
r.get 'new' do
  r.view 'tils.new', errors: []
end
```

So having the ability to set default values in our `views` objects make it simplier.

```ruby
module Tils
  class New < TilWeb::View::Controller
    configure do |config|
      config.template = "tils/new"
    end

    expose :errors, default: []
  end
end
```

What do you think @timriley 
    