### PR TITLE
Allow keyword arguments to be passed in exposure block arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,9 @@ after_success:
     # Send coverage report from the job #1 == current MRI release
   - '[ "${TRAVIS_JOB_NUMBER#*.}" = "1" ] && [ "$TRAVIS_BRANCH" = "master" ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.4.0
-  - 2.3.3
-  - 2.2.6
-  - 2.1.10
+  - 2.4.2
+  - 2.3.5
+  - 2.2.8
   - jruby-9.1.6.0
 env:
   global:

--- a/dry-view.gemspec
+++ b/dry-view.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.1.0'
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_runtime_dependency "tilt", "~> 2.0"
   spec.add_runtime_dependency "dry-core", "~> 0.2"

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -61,16 +61,21 @@ module Dry
       end
 
       def proc_args(input, *dependency_args)
-        proc.parameters.each do |parameter_type, parameter_name|
-          if INPUT_PARAMETER_TYPES.include?(parameter_type) && input.key?(parameter_name)
-            dependency_args << get_key_value(input, parameter_name)
-          end
+        input_args = keyword_args(input)
+
+        if input_args.any?
+          dependency_args << input_args
+        else
+          dependency_args
         end
-        dependency_args
       end
 
-      def get_key_value(input, key)
-        input.select { |k, _| k == key }
+      def keyword_args(input)
+        proc.parameters.each_with_object({}) do |(type, name), args|
+          if INPUT_PARAMETER_TYPES.include?(type) && input.key?(name)
+            args[name] = input[name]
+          end
+        end
       end
 
       def prepare_proc(proc, object)

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -61,11 +61,16 @@ module Dry
       end
 
       def proc_args(input, *dependency_args)
-        if proc.parameters.map(&:first).any? { |type| INPUT_PARAMETER_TYPES.include?(type) }
-          dependency_args << input
-        else
-          dependency_args
+        proc.parameters.each do |parameter_type, parameter_name|
+          if INPUT_PARAMETER_TYPES.include?(parameter_type) && input.key?(parameter_name)
+            dependency_args << get_key_value(input, parameter_name)
+          end
         end
+        dependency_args
+      end
+
+      def get_key_value(input, key)
+        input.select { |k, _| k == key }
       end
 
       def prepare_proc(proc, object)

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -23,7 +23,7 @@ module Dry
         self.class.new(name, proc, obj, options)
       end
 
-      def dependencies
+      def dependency_names
         proc ? proc.parameters.map(&:last) : []
       end
 

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -41,7 +41,7 @@ module Dry
       def call(input, locals = {})
         return input[name] unless proc
 
-        *dependency_args = dependency_names.map { |name|
+        dependency_args = dependency_names.map { |name|
           locals.fetch(name)
         }
 

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -34,13 +34,9 @@ module Dry
       def call(input, locals = {})
         return input[name] unless proc
 
-        args = dependencies.map.with_index { |name, position|
-          if position.zero?
-            locals.fetch(name) { input }
-          else
-            locals.fetch(name)
-          end
-        }
+        args = dependencies.map do |name|
+          locals.fetch(name) { input }
+        end
 
         call_proc(*args)
       end

--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -47,7 +47,7 @@ module Dry
       end
 
       def tsort_each_child(name, &block)
-        self[name].dependencies.each(&block) if exposures.key?(name)
+        self[name].dependency_names.each(&block) if exposures.key?(name)
       end
     end
   end

--- a/spec/fixtures/templates/edit.html.slim
+++ b/spec/fixtures/templates/edit.html.slim
@@ -1,0 +1,11 @@
+h1 Edit
+
+- if errors.any?
+  - errors.each do |error|
+    p.error #{error}
+- else
+  p
+    | No Errors
+
+p
+ = pretty_id

--- a/spec/fixtures/templates/greeting.html.slim
+++ b/spec/fixtures/templates/greeting.html.slim
@@ -1,0 +1,2 @@
+p
+  = greeting

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -184,26 +184,26 @@ RSpec.describe 'exposures' do
     )
   end
 
-  it 'still works accessing the input as before' do
+  it 'only pass keywords arguments that are needit in the block and allow for default values' do
     vc = Class.new(Dry::View::Controller) do
       configure do |config|
         config.paths = SPEC_ROOT.join('fixtures/templates')
         config.layout = 'app'
-        config.template = 'greeting'
+        config.template = 'edit'
         config.default_format = :html
       end
 
-      expose :greeting do |prefix, **input|
-        "#{prefix} #{input.fetch(:greeting)}"
+      expose :pretty_id do |id:|
+        "Beautiful #{id}"
       end
 
-      expose :prefix do
-        'Hello'
+      expose :errors do |errors: []|
+        errors
       end
     end.new
 
-    expect(vc.(greeting: 'From dry-view internals', context: context)).to eql(
-      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><p>Hello From dry-view internals</p></body></html>'
+    expect(vc.(id: 1, context: context)).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h1>Edit</h1><p>No Errors</p><p>Beautiful 1</p></body></html>'
     )
   end
 

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -220,11 +220,7 @@ RSpec.describe 'exposures' do
 
       private
 
-      def users(**input)
-        input.fetch(:users)
-      end
-
-      def users_count(users)
+      def users_count(users:)
         "#{users.length} users"
       end
     end.new
@@ -252,11 +248,9 @@ RSpec.describe 'exposures' do
         "COUNT: "
       end
 
-      expose :users do |**input|
-        input.fetch(:users)
-      end
+      expose :users
 
-      expose :users_count do |prefix, users|
+      expose :users_count do |prefix, users:|
         "#{prefix}#{users.length} users"
       end
     end.new

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe 'exposures' do
 
       expose :users
 
-      expose :users_count do |users|
+      expose :users_count do |users:|
         "#{users.length} users"
       end
     end.new
@@ -193,7 +193,7 @@ RSpec.describe 'exposures' do
         config.default_format = :html
       end
 
-      expose :greeting do |prefix, input|
+      expose :greeting do |prefix, **input|
         "#{prefix} #{input.fetch(:greeting)}"
       end
 
@@ -220,7 +220,7 @@ RSpec.describe 'exposures' do
 
       private
 
-      def users(input)
+      def users(**input)
         input.fetch(:users)
       end
 
@@ -252,7 +252,7 @@ RSpec.describe 'exposures' do
         "COUNT: "
       end
 
-      expose :users do |input|
+      expose :users do |**input|
         input.fetch(:users)
       end
 

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Dry::View::Exposure do
     let(:input) { {name: "Jane"} }
 
     context "proc expects input only" do
-      let(:proc) { -> **input { input[:name] } }
+      let(:proc) { -> name: { name } }
 
       it "sends the input to the proc" do
         expect(exposure.(input)).to eql "Jane"
@@ -136,7 +136,7 @@ RSpec.describe Dry::View::Exposure do
     end
 
     context "proc expects input and dependencies" do
-      let(:proc) { -> greeting, **input { "#{greeting}, #{input[:name]}" } }
+      let(:proc) { -> greeting, name: { "#{greeting}, #{name}" } }
       let(:locals) { {greeting: "Hola"} }
 
       it "sends the input and dependency values to the proc" do
@@ -154,7 +154,7 @@ RSpec.describe Dry::View::Exposure do
     end
 
     context "proc accesses object instance" do
-      let(:proc) { -> **input { "My name is #{input[:name]} but call me #{title} #{input[:name]}" } }
+      let(:proc) { -> name: { "My name is #{name} but call me #{title} #{name}" } }
 
       let(:object) do
         Class.new do

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -125,22 +125,22 @@ RSpec.describe Dry::View::Exposure do
   end
 
   describe "#call" do
-    let(:input) { "input" }
+    let(:input) { {name: "Jane"} }
 
     context "proc expects input only" do
-      let(:proc) { -> input { input } }
+      let(:proc) { -> **input { input[:name] } }
 
       it "sends the input to the proc" do
-        expect(exposure.(input)).to eql "input"
+        expect(exposure.(input)).to eql "Jane"
       end
     end
 
     context "proc expects input and dependencies" do
-      let(:proc) { -> input, greeting { "#{greeting}, #{input}" } }
+      let(:proc) { -> greeting, **input { "#{greeting}, #{input[:name]}" } }
       let(:locals) { {greeting: "Hola"} }
 
       it "sends the input and dependency values to the proc" do
-        expect(exposure.(input, locals)).to eq "Hola, input"
+        expect(exposure.(input, locals)).to eq "Hola, Jane"
       end
     end
 
@@ -154,20 +154,20 @@ RSpec.describe Dry::View::Exposure do
     end
 
     context "proc accesses object instance" do
-      let(:proc) { -> input { "#{input} from #{name}" } }
+      let(:proc) { -> **input { "My name is #{input[:name]} but call me #{title} #{input[:name]}" } }
 
       let(:object) do
         Class.new do
-          attr_reader :name
+          attr_reader :title
 
-          def initialize(name)
-            @name = name
+          def initialize(title)
+            @title = title
           end
-        end.new("Jane")
+        end.new("Dr")
       end
 
       it "makes the instance available as self" do
-        expect(exposure.(input)).to eq "input from Jane"
+        expect(exposure.(input)).to eq "My name is Jane but call me Dr Jane"
       end
     end
 

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -90,12 +90,12 @@ RSpec.describe Dry::View::Exposure do
     end
   end
 
-  describe "#dependencies" do
+  describe "#dependency_names" do
     context "proc provided" do
       let(:proc) { -> input, foo, bar { "hi" } }
 
       it "returns an array of exposure dependencies derived from the proc's argument names" do
-        expect(exposure.dependencies).to eql [:input, :foo, :bar]
+        expect(exposure.dependency_names).to eql [:input, :foo, :bar]
       end
     end
 
@@ -111,7 +111,7 @@ RSpec.describe Dry::View::Exposure do
       end
 
       it "returns an array of exposure dependencies derived from the instance method's argument names" do
-        expect(exposure.dependencies).to eql [:input, :bar, :baz]
+        expect(exposure.dependency_names).to eql [:input, :bar, :baz]
       end
     end
 
@@ -119,7 +119,7 @@ RSpec.describe Dry::View::Exposure do
       let(:proc) { nil }
 
       it "returns no dependencies" do
-        expect(exposure.dependencies).to eql []
+        expect(exposure.dependency_names).to eql []
       end
     end
   end

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dry::View::Exposures do
 
   describe "#add" do
     it "creates and adds an exposure" do
-      proc = -> input { "hi" }
+      proc = -> **input { "hi" }
       exposures.add :hello, proc
 
       expect(exposures[:hello].name).to eq :hello
@@ -43,7 +43,7 @@ RSpec.describe Dry::View::Exposures do
 
   describe "#locals" do
     before do
-      exposures.add(:greeting, -> input { input.fetch(:greeting).upcase })
+      exposures.add(:greeting, -> **input { input.fetch(:greeting).upcase })
       exposures.add(:farewell, -> greeting { "#{greeting} and goodbye" })
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Dry::View::Exposures do
     end
 
     it "does not return any values from private exposures" do
-      exposures.add(:hidden, -> input { "shh" }, private: true)
+      exposures.add(:hidden, -> **input { "shh" }, private: true)
 
       expect(locals).to include(:greeting, :farewell)
       expect(locals).not_to include(:hidden)

--- a/spec/unit/exposures_spec.rb
+++ b/spec/unit/exposures_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Dry::View::Exposures do
 
   describe "#locals" do
     before do
-      exposures.add(:greeting, -> **input { input.fetch(:greeting).upcase })
+      exposures.add(:greeting, -> greeting: { greeting.upcase })
       exposures.add(:farewell, -> greeting { "#{greeting} and goodbye" })
     end
 


### PR DESCRIPTION
Solve #44 

@timriley with this really small change we are able to support passing `keyword` arguments to the exposure block. Also we get `default` 🎉 