### PR TITLE
Allow for renderer to be optional and provide friendly default

### DIFF
--- a/lib/dry/view/default_renderer.rb
+++ b/lib/dry/view/default_renderer.rb
@@ -1,0 +1,9 @@
+module Dry
+  module View
+    class DefaultRenderer
+      def method_missing(name, *args, &block)
+        raise "No renderer provided"
+      end
+    end
+  end
+end

--- a/lib/dry/view/default_renderer.rb
+++ b/lib/dry/view/default_renderer.rb
@@ -1,9 +1,0 @@
-module Dry
-  module View
-    class DefaultRenderer
-      def method_missing(name, *args, &block)
-        raise "No renderer provided"
-      end
-    end
-  end
-end

--- a/lib/dry/view/missing_renderer.rb
+++ b/lib/dry/view/missing_renderer.rb
@@ -1,0 +1,12 @@
+module Dry
+  module View
+    class MissingRenderer
+
+      MissingRendererError = Class.new(StandardError)
+
+      def method_missing(name, *args, &block)
+        raise MissingRendererError, "No renderer provided"
+      end
+    end
+  end
+end

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -1,5 +1,6 @@
 require 'dry-equalizer'
 require 'dry/view/scope'
+require 'dry/view/default_renderer'
 
 module Dry
   module View
@@ -18,9 +19,7 @@ module Dry
 
       attr_reader :_context
 
-      attr_reader :_renderer
-
-      def initialize(name:, value:, renderer:, context: nil)
+      def initialize(name:, value:, renderer: nil, context: nil)
         @_name = name
         @_value = value
         @_context = context
@@ -61,6 +60,10 @@ module Dry
           context: _context,
           renderer: _renderer,
         )
+      end
+
+      def _renderer
+        return @_renderer ? @_renderer : DefaultRenderer.new
       end
     end
   end

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -1,6 +1,6 @@
 require 'dry-equalizer'
 require 'dry/view/scope'
-require 'dry/view/default_renderer'
+require 'dry/view/missing_renderer'
 
 module Dry
   module View
@@ -19,7 +19,9 @@ module Dry
 
       attr_reader :_context
 
-      def initialize(name:, value:, renderer: nil, context: nil)
+      attr_reader :_renderer
+
+      def initialize(name:, value:, renderer: MissingRenderer.new, context: nil)
         @_name = name
         @_value = value
         @_context = context
@@ -60,10 +62,6 @@ module Dry
           context: _context,
           renderer: _renderer,
         )
-      end
-
-      def _renderer
-        return @_renderer ? @_renderer : DefaultRenderer.new
       end
     end
   end

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -5,61 +5,81 @@ RSpec::Matchers.define :template_scope do |locals|
 end
 
 RSpec.describe Dry::View::Part do
-  subject(:part) { described_class.new(name: name, value: value, renderer: renderer, context: context) }
+  context 'with a renderer' do
+    subject(:part) { described_class.new(name: name, value: value, renderer: renderer, context: context) }
 
-  let(:name) { :user }
-  let(:value) { double('value') }
-  let(:context) { double('context') }
-  let(:renderer) { double('renderer') }
+    let(:name) { :user }
+    let(:value) { double('value') }
+    let(:context) { double('context') }
+    let(:renderer) { double('renderer') }
 
-  describe '#render' do
-    before do
-      allow(renderer).to receive(:lookup).with('_info').and_return '_info.html.erb'
-      allow(renderer).to receive(:render)
+    describe '#render' do
+      before do
+        allow(renderer).to receive(:lookup).with('_info').and_return '_info.html.erb'
+        allow(renderer).to receive(:render)
+      end
+
+      it 'renders a partial with the part available in its scope' do
+        part.render(:info)
+        expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(user: part))
+      end
+
+      it 'allows the part to be made available on a different name' do
+        part.render(:info, as: :admin)
+        expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(admin: part))
+      end
+
+      it 'includes extra locals in the scope' do
+        part.render(:info, extra_local: "hello")
+        expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(user: part, extra_local: "hello"))
+      end
     end
 
-    it 'renders a partial with the part available in its scope' do
-      part.render(:info)
-      expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(user: part))
+    describe '#to_s' do
+      before do
+        allow(value).to receive(:to_s).and_return 'to_s on the value'
+      end
+
+      it 'delegates to the wrapped value' do
+        expect(part.to_s).to eq 'to_s on the value'
+      end
     end
 
-    it 'allows the part to be made available on a different name' do
-      part.render(:info, as: :admin)
-      expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(admin: part))
-    end
+    describe '#method_missing' do
+      let(:value) { double(greeting: 'hello from value') }
 
-    it 'includes extra locals in the scope' do
-      part.render(:info, extra_local: "hello")
-      expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(user: part, extra_local: "hello"))
+      it 'calls a matching method on the value' do
+        expect(part.greeting).to eq 'hello from value'
+      end
+
+      it 'forwards all arguments to the method' do
+        blk = -> { }
+        part.greeting 'args', &blk
+
+        expect(value).to have_received(:greeting).with('args', &blk)
+      end
+
+      it 'raises an error if no metho matches' do
+        expect { part.farewell }.to raise_error(NoMethodError)
+      end
     end
   end
 
-  describe '#to_s' do
-    before do
-      allow(value).to receive(:to_s).and_return 'to_s on the value'
-    end
+  context 'without a renderer' do
+    subject(:part) { described_class.new(name: name, value: value, context: context) }
 
-    it 'delegates to the wrapped value' do
-      expect(part.to_s).to eq 'to_s on the value'
-    end
-  end
+    let(:name) { :user }
+    let(:value) { double('value') }
+    let(:context) { double('context') }
 
-  describe '#method_missing' do
-    let(:value) { double(greeting: 'hello from value') }
+    describe '#new' do
+      it 'can be initialised' do
+        expect(part).to be_an_instance_of(Dry::View::Part)
+      end
 
-    it 'calls a matching method on the value' do
-      expect(part.greeting).to eq 'hello from value'
-    end
-
-    it 'forwards all arguments to the method' do
-      blk = -> { }
-      part.greeting 'args', &blk
-
-      expect(value).to have_received(:greeting).with('args', &blk)
-    end
-
-    it 'raises an error if no metho matches' do
-      expect { part.farewell }.to raise_error(NoMethodError)
+      it 'raises an exception when render is called' do
+        expect { part.render(:info) }.to raise_error(RuntimeError).with_message('No renderer provided')
+      end
     end
   end
 end

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Dry::View::Part do
       end
 
       it 'raises an exception when render is called' do
-        expect { part.render(:info) }.to raise_error(RuntimeError).with_message('No renderer provided')
+        expect { part.render(:info) }.to raise_error(Dry::View::MissingRenderer::MissingRendererError).with_message('No renderer provided')
       end
     end
   end


### PR DESCRIPTION
This PR aims to address #43 by making the `renderer:` keyword argument optional when initialising a `View::Part`. 

In addition, a default renderer is provided that raises an exception whenever a method is called on it as a reminder to provide an actual renderer.