### PR TITLE
Add decorated_children to Part class

### DIFF
--- a/lib/dry/view/decorate.rb
+++ b/lib/dry/view/decorate.rb
@@ -1,0 +1,35 @@
+module Dry
+  module View
+    class Decorate
+      attr_reader :name, :options, :proc
+
+      def initialize(name, options, proc)
+        @name = name
+        @options = options
+        @proc = proc
+      end
+
+      def call(local_value, renderer, context)
+        singular_name = singular_name(name)
+        value = local_value.public_send(name)
+        if value.respond_to?(:to_ary)
+          value.map do |val|
+            part_class.new(name: singular_name, value: val, renderer: renderer, context: context)
+          end
+        else
+          part_class.new(name: singular_name, value: value, renderer: renderer, context: context)
+        end
+      end
+
+      def part_class
+        options.fetch(:as)
+      end
+
+      private
+
+      def singular_name(name)
+        Dry::Core::Inflector.singularize(name).to_sym
+      end
+    end
+  end
+end

--- a/lib/dry/view/decorates.rb
+++ b/lib/dry/view/decorates.rb
@@ -17,13 +17,11 @@ module Dry
         decorates.any?
       end
 
-      def each
-        decorates.each do |key, decorate|
-          yield(key, decorate)
-        end
+      def each(&block)
+        decorates.each(&block)
       end
 
-      def add(name, options, block)
+      def add(name, options = {}, block = nil)
         decorates[name] = Decorate.new(name, options, block)
       end
     end

--- a/lib/dry/view/decorates.rb
+++ b/lib/dry/view/decorates.rb
@@ -1,0 +1,31 @@
+require "dry/view/decorate"
+
+module Dry
+  module View
+    class Decorates
+      attr_reader :decorates
+
+      def initialize(decorates = {})
+        @decorates = decorates
+      end
+
+      def [](name)
+        decorates[name]
+      end
+
+      def any?
+        decorates.any?
+      end
+
+      def each
+        decorates.each do |key, decorate|
+          yield(key, decorate)
+        end
+      end
+
+      def add(name, options, block)
+        decorates[name] = Decorate.new(name, options, block)
+      end
+    end
+  end
+end

--- a/lib/dry/view/decorates_resolver.rb
+++ b/lib/dry/view/decorates_resolver.rb
@@ -12,12 +12,18 @@ module Dry
 
       def call(part_class, value, renderer, context)
         part_class.decorates.each do |key, decorate|
-          if decorate.part_class.decorates.any? && value.public_send(key)
+          if decorate.part_class.decorates.any?
             call(decorate.part_class, value, renderer, context)
           end
-          result[key] = decorate.call(value, renderer, context) if value.public_send(key)
+          result[key] = decorate.call(value, renderer, context) if valid_key?(value, key)
         end
         result
+      end
+
+      private
+
+      def valid_key?(value, key)
+        value.respond_to?(key) && value.public_send(key)
       end
     end
   end

--- a/lib/dry/view/decorates_resolver.rb
+++ b/lib/dry/view/decorates_resolver.rb
@@ -1,0 +1,24 @@
+module Dry
+  module View
+    class DecoratesResolver
+      def self.call(part_class, value, renderer, context)
+        new.call(part_class, value, renderer, context)
+      end
+
+      attr_reader :result
+      def initialize
+        @result = {}
+      end
+
+      def call(part_class, value, renderer, context)
+        part_class.decorates.each do |key, decorate|
+          if decorate.part_class.decorates.any? && value.public_send(key)
+            call(decorate.part_class, value, renderer, context)
+          end
+          result[key] = decorate.call(value, renderer, context) if value.public_send(key)
+        end
+        result
+      end
+    end
+  end
+end

--- a/lib/dry/view/decorator.rb
+++ b/lib/dry/view/decorator.rb
@@ -11,7 +11,7 @@ module Dry
       def call(name, value, renderer:, context:, **options)
         klass = part_class(name, value, options)
 
-        decorated_childs = if klass.decorates.any?
+        decorated_children = if klass.decorates.any?
                              DecoratesResolver.call(klass, value, renderer, context)
                            else
                              {}
@@ -25,9 +25,9 @@ module Dry
             call(singular_name, obj, renderer: renderer, context: context, **singular_options)
           }
 
-          klass.new(name: name, value: arr, renderer: renderer, context: context, decorated_childs: decorated_childs)
+          klass.new(name: name, value: arr, renderer: renderer, context: context, decorated_children: decorated_children)
         else
-          klass.new(name: name, value: value, renderer: renderer, context: context, decorated_childs: decorated_childs)
+          klass.new(name: name, value: value, renderer: renderer, context: context, decorated_children: decorated_children)
         end
       end
 

--- a/lib/dry/view/decorator.rb
+++ b/lib/dry/view/decorator.rb
@@ -1,5 +1,6 @@
 require 'dry/core/inflector'
 require 'dry/view/part'
+require 'dry/view/decorates_resolver'
 
 module Dry
   module View
@@ -10,6 +11,12 @@ module Dry
       def call(name, value, renderer:, context:, **options)
         klass = part_class(name, value, options)
 
+        decorated_childs = if klass.decorates.any?
+                             DecoratesResolver.call(klass, value, renderer, context)
+                           else
+                             {}
+                           end
+
         if value.respond_to?(:to_ary)
           singular_name = Dry::Core::Inflector.singularize(name).to_sym
           singular_options = singularize_options(options)
@@ -18,9 +25,9 @@ module Dry
             call(singular_name, obj, renderer: renderer, context: context, **singular_options)
           }
 
-          klass.new(name: name, value: arr, renderer: renderer, context: context)
+          klass.new(name: name, value: arr, renderer: renderer, context: context, decorated_childs: decorated_childs)
         else
-          klass.new(name: name, value: value, renderer: renderer, context: context)
+          klass.new(name: name, value: value, renderer: renderer, context: context, decorated_childs: decorated_childs)
         end
       end
 

--- a/lib/dry/view/decorator.rb
+++ b/lib/dry/view/decorator.rb
@@ -11,20 +11,15 @@ module Dry
       def call(name, value, renderer:, context:, **options)
         klass = part_class(name, value, options)
 
-        decorated_children = if klass.decorates.any?
-                             DecoratesResolver.call(klass, value, renderer, context)
-                           else
-                             {}
-                           end
+        decorated_children = DecoratesResolver.call(klass, value, renderer, context)
 
         if value.respond_to?(:to_ary)
           singular_name = Dry::Core::Inflector.singularize(name).to_sym
           singular_options = singularize_options(options)
 
           arr = value.to_ary.map { |obj|
-            call(singular_name, obj, renderer: renderer, context: context, **singular_options)
-          }
-
+                  call(singular_name, obj, renderer: renderer, context: context, **singular_options)
+                }
           klass.new(name: name, value: arr, renderer: renderer, context: context, decorated_children: decorated_children)
         else
           klass.new(name: name, value: value, renderer: renderer, context: context, decorated_children: decorated_children)

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -1,5 +1,6 @@
 require 'dry-equalizer'
 require 'dry/view/scope'
+require 'dry/view/decorates'
 require 'dry/view/missing_renderer'
 
 module Dry
@@ -11,6 +12,14 @@ module Dry
         value
       ].freeze
 
+      def self.decorate(name, **options, &block)
+        decorates.add(name, options, block)
+      end
+
+      def self.decorates
+        @decorates ||= Decorates.new
+      end
+
       include Dry::Equalizer(:_name, :_value, :_context, :_renderer)
 
       attr_reader :_name
@@ -21,11 +30,14 @@ module Dry
 
       attr_reader :_renderer
 
-      def initialize(name:, value:, renderer: MissingRenderer.new, context: nil)
+      attr_reader :_decorated_childs
+
+      def initialize(name:, value:, renderer: MissingRenderer.new, context: nil, decorated_childs: {})
         @_name = name
         @_value = value
         @_context = context
         @_renderer = renderer
+        @_decorated_childs = decorated_childs
       end
 
       def _render(partial_name, as: _name, **locals, &block)
@@ -43,7 +55,9 @@ module Dry
       private
 
       def method_missing(name, *args, &block)
-        if _value.respond_to?(name)
+        if _decorated_childs.key?(name)
+          _decorated_childs[name]
+        elsif _value.respond_to?(name)
           _value.public_send(name, *args, &block)
         elsif CONVENIENCE_METHODS.include?(name)
           __send__(:"_#{name}", *args, &block)

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -30,14 +30,14 @@ module Dry
 
       attr_reader :_renderer
 
-      attr_reader :_decorated_childs
+      attr_reader :_decorated_children
 
-      def initialize(name:, value:, renderer: MissingRenderer.new, context: nil, decorated_childs: {})
+      def initialize(name:, value:, renderer: MissingRenderer.new, context: nil, decorated_children: {})
         @_name = name
         @_value = value
         @_context = context
         @_renderer = renderer
-        @_decorated_childs = decorated_childs
+        @_decorated_children = decorated_children
       end
 
       def _render(partial_name, as: _name, **locals, &block)
@@ -55,8 +55,8 @@ module Dry
       private
 
       def method_missing(name, *args, &block)
-        if _decorated_childs.key?(name)
-          _decorated_childs[name]
+        if _decorated_children.key?(name)
+          _decorated_children[name]
         elsif _value.respond_to?(name)
           _value.public_send(name, *args, &block)
         elsif CONVENIENCE_METHODS.include?(name)

--- a/spec/fixtures/templates/decorated_parts_product_children.html.slim
+++ b/spec/fixtures/templates/decorated_parts_product_children.html.slim
@@ -1,0 +1,2 @@
+- product.tags.each do |tag|
+  p = tag

--- a/spec/fixtures/templates/decorated_parts_product_children_non_array.html.slim
+++ b/spec/fixtures/templates/decorated_parts_product_children_non_array.html.slim
@@ -1,0 +1,1 @@
+p = product.tags

--- a/spec/fixtures/templates/decorated_parts_product_children_with_prices.html.slim
+++ b/spec/fixtures/templates/decorated_parts_product_children_with_prices.html.slim
@@ -1,0 +1,5 @@
+- product.tags.each do |tag|
+  p = tag
+
+- product.prices.each do |price|
+  p = price

--- a/spec/unit/decorate_spec.rb
+++ b/spec/unit/decorate_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Dry::View::Decorate do
+  subject(:decorate) { described_class.new(:products, options, nil) }
+  let(:options) { {as: Dry::View::Part} }
+  let(:context) { double(:context) }
+  let(:renderer) { double(:renderer) }
+
+  describe '#part_class' do
+    it 'return part class' do
+      expect(decorate.part_class).to eq Dry::View::Part
+    end
+  end
+
+  describe '#call' do
+    let(:result) { decorate.call(OpenStruct.new(products: value), renderer, context) }
+
+    context 'single value' do
+      let(:value) { 'hello' }
+
+      it 'return part object' do
+        expect(result.class).to eq Dry::View::Part
+        expect(result.value).to eq value
+      end
+
+      it 'return part object with singular name' do
+        expect(result._name).to eq :product
+      end
+    end
+
+    context 'array value' do
+      let(:value) { ['hello', 'world'] }
+
+      it 'return array with part objects' do
+        expect(result.class).to eq Array
+        expect(result.size).to eq 2
+        expect(result.last.class).to eq Dry::View::Part
+        expect(result.last.value).to eq 'world'
+      end
+
+      it 'return part object with singular name' do
+        expect(result.first._name).to eq :product
+      end
+    end
+  end
+end

--- a/spec/unit/decorates_resolver_spec.rb
+++ b/spec/unit/decorates_resolver_spec.rb
@@ -1,0 +1,116 @@
+RSpec.describe Dry::View::DecoratesResolver do
+  before do
+    module Test
+      class TagPart < Dry::View::Part
+        def to_s
+          "Custom tag wrapping #{_value}"
+        end
+      end
+      class NestedPart < Dry::View::Part
+        decorate :tags, as: TagPart
+        def to_s
+          "Custom nested wrapping #{_value}"
+        end
+      end
+
+      class CustomPart < Dry::View::Part
+        def to_s
+          "Custom part wrapping #{_value}"
+        end
+      end
+    end
+  end
+  subject(:decorates_resolver) { described_class.new }
+  let(:renderer) { double('renderer') }
+  let(:context) { double('context') }
+
+  describe "#result" do
+    it "is empty by defalut" do
+      expect(decorates_resolver.result).to be_empty
+    end
+  end
+
+  describe '#call' do
+    let(:result) { decorates_resolver.call(part_class, value, renderer, context) }
+
+    context 'Part without decorates' do
+      let(:part_class) do
+        Class.new(Dry::View::Part) do
+          def to_s
+            'Nothing special'
+          end
+        end
+      end
+      let(:value) { {} }
+
+      it 'return empty result' do
+        expect(result).to eq({})
+      end
+    end
+
+    context 'Part with decorates' do
+      let(:part_class) do
+        Class.new(Dry::View::Part) do
+          decorate :prices, as: Test::CustomPart
+
+          def to_s
+            'Nothing special'
+          end
+        end
+      end
+
+      context 'when value respond to key' do
+        let(:value) { OpenStruct.new(prices: 'hello') }
+
+        it 'return result with key' do
+          expect(result.keys).to eq([:prices])
+        end
+
+        it 'return result with value wrap in Part class' do
+          expect(result[:prices].class).to eq Test::CustomPart
+        end
+      end
+
+      context 'when value do not respond to key' do
+        let(:value) { OpenStruct.new(products: 'hello') }
+
+        it 'return empty result' do
+          expect(result).to eq({})
+        end
+      end
+    end
+
+    context 'Part with nested decorate' do
+      let(:part_class) do
+        Class.new(Dry::View::Part) do
+          decorate :prices, as: Test::NestedPart
+
+          def to_s
+            'Nothing special'
+          end
+        end
+      end
+
+      context 'when value respond to key' do
+        let(:value) { OpenStruct.new(prices: 'hello', tags: [1,2]) }
+
+        it 'return result with keys' do
+          expect(result.keys).to eq([:tags, :prices])
+        end
+
+        it 'return result with values wrap in Part class' do
+          expect(result[:prices].class).to eq Test::NestedPart
+          expect(result[:tags].first.class).to eq Test::TagPart
+        end
+      end
+
+      context 'when value do not respond to key' do
+        let(:value) { OpenStruct.new(products: 'hello', tags: [1,2]) }
+
+        it 'return result with key' do
+          expect(result.keys).to eq([:tags])
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/decorates_spec.rb
+++ b/spec/unit/decorates_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe Dry::View::Decorates do
+  subject(:decorates) { described_class.new }
+
+  describe "#decorates" do
+    it "is empty by defalut" do
+      expect(decorates.decorates).to be_empty
+    end
+  end
+
+  describe "#add" do
+    it "creates and adds a decorate" do
+      options = {foo: :bar}
+      decorates.add :hello, options
+
+      expect(decorates[:hello].name).to eq :hello
+      expect(decorates[:hello].options).to eq options
+    end
+  end
+
+  describe "#each" do
+    before do
+      decorates.add(:greeting, {foo: :bar})
+    end
+
+
+    it "yield each key and decorate object" do
+      decorate = decorates[:greeting]
+      expect { |b| decorates.each(&b) }.to yield_with_args([:greeting, decorate])
+    end
+  end
+end


### PR DESCRIPTION
#45 

This allows to user to use the `decorate` API in there `Part` objects.

I introduce a new argument to the `Part` class `decorated_childs` I went this way because after decorating all the children I didn't want to modify the actual `value` pass to the decorator. I think modifying the actual `value` will end up generating errors.

Maybe instead of creating this `decorated_childs` object, we can have another extraction that is the combination of multiple parts that will delegate all methods that are call in our `Part` object something like `Part::Values` and we can pass multiple parts objects to it.

Since is a work in progress I have only added the `integration` test to prove that it works, once we have a winner on how to deal with it I will provide the `unit` test