### PR TITLE
Make partial rendering a dedicated role of the renderer

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -10,6 +10,8 @@ require 'dry/view/scope'
 module Dry
   module View
     class Controller
+      UndefinedTemplateError = Class.new(StandardError)
+
       DEFAULT_LAYOUTS_DIR = 'layouts'.freeze
       DEFAULT_CONTEXT = Object.new.freeze
       EMPTY_LOCALS = {}.freeze
@@ -80,6 +82,8 @@ module Dry
 
       # @api public
       def call(format: config.default_format, context: config.context, **input)
+        raise UndefinedTemplateError, "no +template+ configured" unless template_path
+
         renderer = self.class.renderer(format)
 
         template_content = renderer.template(template_path, template_scope(renderer, context, input))

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -82,11 +82,11 @@ module Dry
       def call(format: config.default_format, context: config.context, **input)
         renderer = self.class.renderer(format)
 
-        template_content = renderer.(template_path, template_scope(renderer, context, input))
+        template_content = renderer.template(template_path, template_scope(renderer, context, input))
 
         return template_content unless layout?
 
-        renderer.(layout_path, layout_scope(renderer, context)) do
+        renderer.template(layout_path, layout_scope(renderer, context)) do
           template_content
         end
       end

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -29,11 +29,7 @@ module Dry
       end
 
       def _render(partial_name, as: _name, **locals, &block)
-        _renderer.render(
-          _partial(partial_name),
-          _render_scope(as, locals),
-          &block
-        )
+        _renderer.partial(partial_name, _render_scope(as, locals), &block)
       end
 
       def to_s
@@ -50,10 +46,6 @@ module Dry
         else
           super
         end
-      end
-
-      def _partial(name)
-        _renderer.lookup("_#{name}")
       end
 
       def _render_scope(name, **locals)

--- a/lib/dry/view/renderer.rb
+++ b/lib/dry/view/renderer.rb
@@ -23,26 +23,19 @@ module Dry
         @tilts = self.class.tilts
       end
 
-      def call(template, scope, &block)
-        path = lookup(template)
+      def template(name, scope, &block)
+        path = lookup(name)
 
         if path
           render(path, scope, &block)
         else
-          msg = "Template #{template.inspect} could not be found in paths:\n#{paths.map { |pa| "- #{pa.to_s}" }.join("\n")}"
+          msg = "Template #{name.inspect} could not be found in paths:\n#{paths.map { |pa| "- #{pa.to_s}" }.join("\n")}"
           raise TemplateNotFoundError, msg
         end
       end
 
-      def partial(template, scope, &block)
-        path = lookup_partial(template)
-
-        if path
-          render(path, scope, &block)
-        else
-          msg = "Partial #{template.inspect} could not be found in paths:\n#{paths.map { |pa| "- #{pa.to_s}" }.join("\n")}"
-          raise TemplateNotFoundError, msg
-        end
+      def partial(name, scope, &block)
+        template(name_for_partial(name), scope, &block)
       end
 
       def render(path, scope, &block)
@@ -61,14 +54,12 @@ module Dry
         }
       end
 
-      def lookup_partial(name)
+      private
+
+      def name_for_partial(name)
         name_segments = name.to_s.split(PATH_DELIMITER)
         partial_name = name_segments[0..-2].push("#{PARTIAL_PREFIX}#{name_segments[-1]}").join(PATH_DELIMITER)
-
-        lookup(partial_name)
       end
-
-      private
 
       # TODO: make default_encoding configurable
       def tilt(path)

--- a/lib/dry/view/renderer.rb
+++ b/lib/dry/view/renderer.rb
@@ -4,6 +4,9 @@ require 'dry-equalizer'
 module Dry
   module View
     class Renderer
+      PARTIAL_PREFIX = "_".freeze
+      PATH_DELIMITER = "/".freeze
+
       include Dry::Equalizer(:paths, :format)
 
       TemplateNotFoundError = Class.new(StandardError)
@@ -31,6 +34,17 @@ module Dry
         end
       end
 
+      def partial(template, scope, &block)
+        path = lookup_partial(template)
+
+        if path
+          render(path, scope, &block)
+        else
+          msg = "Partial #{template.inspect} could not be found in paths:\n#{paths.map { |pa| "- #{pa.to_s}" }.join("\n")}"
+          raise TemplateNotFoundError, msg
+        end
+      end
+
       def render(path, scope, &block)
         tilt(path).render(scope, &block)
       end
@@ -45,6 +59,13 @@ module Dry
         paths.inject(false) { |result, path|
           result || path.lookup(name, format)
         }
+      end
+
+      def lookup_partial(name)
+        name_segments = name.to_s.split(PATH_DELIMITER)
+        partial_name = name_segments[0..-2].push("#{PARTIAL_PREFIX}#{name_segments[-1]}").join(PATH_DELIMITER)
+
+        lookup(partial_name)
       end
 
       private

--- a/lib/dry/view/scope.rb
+++ b/lib/dry/view/scope.rb
@@ -5,8 +5,6 @@ module Dry
     class Scope
       include Dry::Equalizer(:_locals, :_context, :_renderer)
 
-      PartialNotFoundError = Class.new(StandardError)
-
       attr_reader :_locals
       attr_reader :_context
       attr_reader :_renderer
@@ -18,18 +16,7 @@ module Dry
       end
 
       def render(partial_name, **locals, &block)
-        path = __partial(partial_name)
-
-        if path
-          _renderer.render(
-            path,
-            __render_scope(locals),
-            &block
-            )
-        else
-          msg = "Partial #{partial_name.inspect} could not be found in any path or shared folder"
-          raise PartialNotFoundError, msg
-        end
+        _renderer.partial(partial_name, __render_scope(locals), &block)
       end
 
       private
@@ -42,10 +29,6 @@ module Dry
         else
           super
         end
-      end
-
-      def __partial(name)
-        _renderer.lookup("_#{name}")
       end
 
       def __render_scope(**locals)

--- a/spec/fixtures/templates/_hello.html.slim
+++ b/spec/fixtures/templates/_hello.html.slim
@@ -1,0 +1,1 @@
+h1 Partial hello

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -1,18 +1,13 @@
 RSpec.describe Dry::View::Controller do
-  subject(:layout) { layout_class.new }
-
-  let(:layout_class) do
-    klass = Class.new(Dry::View::Controller)
-
-    klass.configure do |config|
-      config.paths = SPEC_ROOT.join('fixtures/templates')
-      config.layout = 'app'
-      config.template = 'user'
-      config.default_format = :html
-    end
-
-    klass
-  end
+  subject(:controller) {
+    Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app'
+        config.template = 'user'
+      end
+    end.new
+  }
 
   let(:page) do
     double(:page, title: 'Test')
@@ -22,15 +17,21 @@ RSpec.describe Dry::View::Controller do
     { context: page, locals: { user: { name: 'Jane' }, header: { title: 'User' } } }
   end
 
-  let(:renderer) do
-    layout.class.renderers[:html]
-  end
-
   describe '#call' do
     it 'renders template within the layout' do
-      expect(layout.(options)).to eql(
+      expect(controller.(options)).to eql(
         '<!DOCTYPE html><html><head><title>Test</title></head><body><h1>User</h1><p>Jane</p></body></html>'
       )
+    end
+
+    it 'provides a meaningful error if the template name is missing' do
+      controller = Class.new(Dry::View::Controller) do
+        configure do |config|
+          config.paths = SPEC_ROOT.join('fixtures/templates')
+        end
+      end.new
+
+      expect { controller.(options) }.to raise_error Dry::View::Controller::UndefinedTemplateError
     end
   end
 end

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -9,29 +9,24 @@ RSpec.describe Dry::View::Part do
     subject(:part) { described_class.new(name: name, value: value, renderer: renderer, context: context) }
 
     let(:name) { :user }
-    let(:value) { double('value') }
-    let(:context) { double('context') }
-    let(:renderer) { double('renderer') }
+    let(:value) { double(:value) }
+    let(:context) { double(:context) }
+    let(:renderer) { spy(:renderer) }
 
     describe '#render' do
-      before do
-        allow(renderer).to receive(:lookup).with('_info').and_return '_info.html.erb'
-        allow(renderer).to receive(:render)
-      end
-
       it 'renders a partial with the part available in its scope' do
         part.render(:info)
-        expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(user: part))
+        expect(renderer).to have_received(:partial).with(:info, template_scope(user: part))
       end
 
       it 'allows the part to be made available on a different name' do
         part.render(:info, as: :admin)
-        expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(admin: part))
+        expect(renderer).to have_received(:partial).with(:info, template_scope(admin: part))
       end
 
       it 'includes extra locals in the scope' do
         part.render(:info, extra_local: "hello")
-        expect(renderer).to have_received(:render).with('_info.html.erb', template_scope(user: part, extra_local: "hello"))
+        expect(renderer).to have_received(:partial).with(:info, template_scope(user: part, extra_local: "hello"))
       end
     end
 

--- a/spec/unit/renderer_spec.rb
+++ b/spec/unit/renderer_spec.rb
@@ -3,28 +3,55 @@ require 'dry/view/renderer'
 
 RSpec.describe Dry::View::Renderer do
   subject(:renderer) do
-    Dry::View::Renderer.new([Dry::View::Path.new(SPEC_ROOT.join('fixtures/templates'))], format: 'html')
+    Dry::View::Renderer.new(
+      [Dry::View::Path.new(SPEC_ROOT.join('fixtures/templates'))],
+      format: 'html'
+    )
   end
 
   let(:scope) { double(:scope) }
 
-  describe '#call' do
-    it 'renders template' do
-      expect(renderer.('hello', scope)).to eql('<h1>Hello</h1>')
+  describe '#template' do
+    it 'renders template in current directory' do
+      expect(renderer.template(:hello, scope)).to eql('<h1>Hello</h1>')
     end
 
-    it 'looks up shared template in current dir' do
-      expect(renderer.('_shared_hello', scope)).to eql('<h1>Hello</h1>')
+    it 'renders template in shared/ subdirectory' do
+      expect(renderer.template(:_shared_hello, scope)).to eql('<h1>Hello</h1>')
     end
 
-    it 'looks up shared template in upper dir' do
-      expect(renderer.chdir('greetings').('_shared_hello', scope)).to eql('<h1>Hello</h1>')
+    it 'renders template in upper directory' do
+      expect(renderer.chdir('nested').template(:_shared_hello, scope)).to eql('<h1>Hello</h1>')
     end
 
-    it 'raises error when template was not found' do
+    it 'raises error when template cannot be found' do
       expect {
-        renderer.('not_found', scope)
-      }.to raise_error(Dry::View::Renderer::TemplateNotFoundError, /not_found/)
+        renderer.template(:missing_template, scope)
+      }.to raise_error(Dry::View::Renderer::TemplateNotFoundError, /missing_template/)
+    end
+  end
+
+  describe '#partial' do
+    it 'renders partial in current directory' do
+      expect(renderer.partial(:hello, scope)).to eql('<h1>Partial hello</h1>')
+    end
+
+    it 'renders partial in shared/ subdirectory' do
+      expect(renderer.partial(:shared_hello, scope)).to eql('<h1>Hello</h1>')
+    end
+
+    it 'renders partial in upper directory' do
+      expect(renderer.chdir('nested').partial(:hello, scope)).to eql('<h1>Partial hello</h1>')
+    end
+
+    it 'renders partial in upper shared/ subdirectory' do
+      expect(renderer.chdir('nested').partial(:shared_hello, scope)).to eql('<h1>Hello</h1>')
+    end
+
+    it 'raises error when partial cannot be found' do
+      expect {
+        renderer.partial(:missing_partial, scope)
+      }.to raise_error(Dry::View::Renderer::TemplateNotFoundError, /_missing_partial/)
     end
   end
 end

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -2,40 +2,20 @@ RSpec.describe Dry::View::Scope do
   subject(:scope) { described_class.new(renderer: renderer, context: context, locals: locals) }
 
   let(:locals) { {} }
-  let(:context) { double('context') }
-  let(:renderer) { double('renderer') }
+  let(:context) { double(:context) }
+  let(:renderer) { spy(:renderer) }
 
   describe '#render' do
-    context 'partial found' do
-      before do
-        allow(renderer).to receive(:lookup).with('_info').and_return '_info.html.erb'
-        allow(renderer).to receive(:render)
-      end
-
-      it 'renders a partial with itself as the scope' do
-        scope.render(:info)
-        expect(renderer).to have_received(:render).with('_info.html.erb', scope)
-      end
-
-      it 'renders a partial with provided locals' do
-        scope_with_locals = described_class.new(renderer: renderer, context: context, locals: {foo: 'bar'})
-
-        scope.render(:info, foo: 'bar')
-        expect(renderer).to have_received(:render).with('_info.html.erb', scope_with_locals)
-      end
+    it 'renders a partial with itself as the scope' do
+      scope.render(:info)
+      expect(renderer).to have_received(:partial).with(:info, scope)
     end
 
-    context 'partial not found' do
-      before do
-        allow(renderer).to receive(:lookup).with('_info').and_return false
-        allow(renderer).to receive(:render)
-      end
+    it 'renders a partial with provided locals' do
+      scope_with_locals = described_class.new(renderer: renderer, context: context, locals: {foo: 'bar'})
 
-      it 'raises error when partial was not found' do
-        expect {
-          scope.render(:info)
-        }.to raise_error(Dry::View::Scope::PartialNotFoundError, /info/)
-      end
+      scope.render(:info, foo: 'bar')
+      expect(renderer).to have_received(:partial).with(:info, scope_with_locals)
     end
   end
 


### PR DESCRIPTION
Do this by adding a `Renderer#partial` method and centralizing the logic around handling partials into Renderer. This means partial handling is no longer spread around `Part` and `Scope`.

At the same time, allow partials nested within subdirectories by translating partials named `"foo/bar"` into `"foo/_bar"` before doing the template lookup and rendering. This makes it easier for 3rd party gems shipping their own dry-view partials to prevent naming collisions with partials shipped as part of an app. n.b. partial files are still found using the same lookup path, this just allows some nesting within each of those directories.

I need this latter change particularly because I'm building up [icy-form](https://github.com/icelab/icy-form), which will ship with its own dry-view partials. Having the partials collected under the same subdirectory (e.g. `icy_form/_form`, `icy_form/_text_field`, etc.) seemed much nicer than having to organise them within a single flat namespace.

I wanted to get this initial change up as a PR so you could take a look at it (:wave: @solnic, @GustavoCaso, @flash-gordon). If there are no objections, I'll fix the specs I broke and add a few more in, and then we can probably make a new release.