### PR TITLE
Parts with decorated attributes

### DIFF
--- a/lib/dry/view/decorator.rb
+++ b/lib/dry/view/decorator.rb
@@ -18,9 +18,9 @@ module Dry
             call(singular_name, obj, renderer: renderer, context: context, **singular_options)
           }
 
-          klass.new(name: name, value: arr, renderer: renderer, context: context)
+          klass.new(name: name, value: arr, decorator: self, renderer: renderer, context: context)
         else
-          klass.new(name: name, value: value, renderer: renderer, context: context)
+          klass.new(name: name, value: value, decorator: self, renderer: renderer, context: context)
         end
       end
 

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -26,8 +26,10 @@ module Dry
       attr_reader :_decorated_attributes
 
       # @api public
-      def self.decorate(name, **options)
-        decorated_attributes[name] = options
+      def self.decorate(*names, **options)
+        names.each do |name|
+          decorated_attributes[name] = options
+        end
       end
 
       # @api private

--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -11,27 +11,19 @@ module Dry
         value
       ].freeze
 
-      include Dry::Equalizer(:_name, :_value, :_context, :_renderer)
+      include Dry::Equalizer(:_name, :_value, :_decorator, :_context, :_renderer)
 
       attr_reader :_name
 
       attr_reader :_value
 
-      attr_reader :_decorated_attributes
-
       attr_reader :_context
 
       attr_reader :_renderer
 
-      def new(klass = (self.class), name: (_name), value: (_value), **options)
-        klass.new(
-          name: name,
-          value: value,
-          context: _context,
-          renderer: _renderer,
-          **options,
-        )
-      end
+      attr_reader :_decorator
+
+      attr_reader :_decorated_attributes
 
       # @api public
       def self.decorate(name, **options)
@@ -49,6 +41,7 @@ module Dry
         @_value = value
         @_context = context
         @_renderer = renderer
+        @_decorator = decorator
 
         @_decorated_attributes = self.class.decorated_attributes.each_with_object({}) { |(attr_name, options), attrs|
           attrs[attr_name] = decorator.(
@@ -67,6 +60,17 @@ module Dry
 
       def to_s
         _value.to_s
+      end
+
+      def new(klass = (self.class), name: (_name), value: (_value), **options)
+        klass.new(
+          name: name,
+          value: value,
+          context: _context,
+          renderer: _renderer,
+          decorator: _decorator,
+          **options,
+        )
       end
 
       private

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe 'Part / Decorated attributes' do
+  let(:article_class) { Struct.new('Article', :title, :author, :comments, keyword_init: true) }
+  let(:author_class) { Struct.new('Author', :name, keyword_init: true) }
+  let(:comment_class) { Struct.new('Comment', :author, :body, keyword_init: true) }
+
+  let(:article_part_class) {
+    Class.new(Dry::View::Part) do
+      decorate :author
+      decorate :comments
+    end
+  }
+
+  context 'using default decorator' do
+    subject(:article_part) {
+      article_part_class.new(
+        name: :article,
+        value: article,
+      )
+    }
+
+    let(:article) {
+      article_class.new(
+        title: 'Hello world',
+        author: author_class.new(name: 'Jane Doe'),
+        comments: [
+          comment_class.new(author: author_class.new(name: 'Sue Smith'), body: 'Great article')
+        ]
+      )
+    }
+
+    it 'decorates exposures with the standard Dry::View::Part class' do
+      # byebug
+      expect(article_part.author).to be_a Dry::View::Part
+      # expect(article_part.comments[0]).to be_a Dry::View::Part
+    end
+  end
+end

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Part / Decorated attributes' do
     )
   }
 
-  context 'using default decorator' do
+  describe 'using default decorator' do
     subject(:article_part) {
       article_part_class.new(
         name: :article,
@@ -50,21 +50,36 @@ RSpec.describe 'Part / Decorated attributes' do
       )
     }
 
-    context 'decorating without options' do
-      let(:article_part_class) {
-        Class.new(Dry::View::Part) do
-          decorate :author
-          decorate :comments
-        end
-      }
+    describe 'decorating without options' do
+      describe 'multiple declarations' do
+        let(:article_part_class) {
+          Class.new(Dry::View::Part) do
+            decorate :author
+            decorate :comments
+          end
+        }
 
-      it 'decorates exposures with the standard Dry::View::Part class' do
-        expect(article_part.author).to be_a Dry::View::Part
-        expect(article_part.comments[0]).to be_a Dry::View::Part
+        it 'decorates exposures with the standard Dry::View::Part class' do
+          expect(article_part.author).to be_a Dry::View::Part
+          expect(article_part.comments[0]).to be_a Dry::View::Part
+        end
+      end
+
+      describe 'single declaration' do
+        let(:article_part_class) {
+          Class.new(Dry::View::Part) do
+            decorate :author, :comments
+          end
+        }
+
+        it 'decorates exposures with the standard Dry::View::Part class' do
+          expect(article_part.author).to be_a Dry::View::Part
+          expect(article_part.comments[0]).to be_a Dry::View::Part
+        end
       end
     end
 
-    context 'decorating with part class specified' do
+    describe 'decorating with part class specified' do
       before do
         module Test
           class AuthorPart < Dry::View::Part
@@ -89,7 +104,7 @@ RSpec.describe 'Part / Decorated attributes' do
     end
   end
 
-  context 'using custom decorator' do
+  describe 'using custom decorator' do
     let(:article_part_class) {
         Class.new(Dry::View::Part) do
           decorate :author

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -32,21 +32,7 @@ RSpec.describe 'Part / Decorated attributes' do
     end
   }
 
-  let(:article_part_class) {
-    Class.new(Dry::View::Part) do
-      decorate :author
-      decorate :comments
-    end
-  }
-
   context 'using default decorator' do
-    subject(:article_part) {
-      article_part_class.new(
-        name: :article,
-        value: article,
-      )
-    }
-
     let(:article) {
       article_class.new(
         title: 'Hello world',
@@ -57,9 +43,49 @@ RSpec.describe 'Part / Decorated attributes' do
       )
     }
 
-    it 'decorates exposures with the standard Dry::View::Part class' do
-      expect(article_part.author).to be_a Dry::View::Part
-      expect(article_part.comments[0]).to be_a Dry::View::Part
+    subject(:article_part) {
+      article_part_class.new(
+        name: :article,
+        value: article,
+      )
+    }
+
+    context 'without options' do
+      let(:article_part_class) {
+        Class.new(Dry::View::Part) do
+          decorate :author
+          decorate :comments
+        end
+      }
+
+      it 'decorates exposures with the standard Dry::View::Part class' do
+        expect(article_part.author).to be_a Dry::View::Part
+        expect(article_part.comments[0]).to be_a Dry::View::Part
+      end
+    end
+
+    context 'with part class specified' do
+      before do
+        module Test
+          class AuthorPart < Dry::View::Part
+          end
+
+          class CommentPart < Dry::View::Part
+          end
+        end
+      end
+
+      let(:article_part_class) {
+        Class.new(Dry::View::Part) do
+          decorate :author, as: Test::AuthorPart
+          decorate :comments, as: Test::CommentPart
+        end
+      }
+
+      it 'deorates exposures with the specified part class' do
+        expect(article_part.author).to be_a Test::AuthorPart
+        expect(article_part.comments[0]).to be_a Test::CommentPart
+      end
     end
   end
 end

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -1,7 +1,36 @@
 RSpec.describe 'Part / Decorated attributes' do
-  let(:article_class) { Struct.new('Article', :title, :author, :comments, keyword_init: true) }
-  let(:author_class) { Struct.new('Author', :name, keyword_init: true) }
-  let(:comment_class) { Struct.new('Comment', :author, :body, keyword_init: true) }
+  let(:article_class) {
+    Class.new do
+      attr_reader :title, :author, :comments
+
+      def initialize(title:, author:, comments:)
+        @title = title
+        @author = author
+        @comments = comments
+      end
+    end
+  }
+
+  let(:author_class) {
+    Class.new do
+      attr_reader :name
+
+      def initialize(name:)
+        @name = name
+      end
+    end
+  }
+
+  let(:comment_class) {
+    Class.new do
+      attr_reader :author, :body
+
+      def initialize(author:, body:)
+        @author = author
+        @body = body
+      end
+    end
+  }
 
   let(:article_part_class) {
     Class.new(Dry::View::Part) do

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -58,9 +58,8 @@ RSpec.describe 'Part / Decorated attributes' do
     }
 
     it 'decorates exposures with the standard Dry::View::Part class' do
-      # byebug
       expect(article_part.author).to be_a Dry::View::Part
-      # expect(article_part.comments[0]).to be_a Dry::View::Part
+      expect(article_part.comments[0]).to be_a Dry::View::Part
     end
   end
 end

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -30,39 +30,6 @@ RSpec.describe Dry::View::Part do
       end
     end
 
-    describe '#new' do
-      let(:renderer) do
-        Dry::View::Renderer.new(
-          [Dry::View::Path.new(SPEC_ROOT.join('fixtures/templates'))],
-          format: 'html'
-        )
-      end
-
-      let(:part) { described_class.new(name: name, value: value, context: context, renderer: renderer) }
-
-      context 'same renderer' do
-        it 'renders correctly' do
-          new_part = part.new(value: 'new value')
-          expect(part._render(:hello)).to eql(new_part._render(:hello))
-        end
-      end
-
-      context 'new renderer' do
-        let(:new_renderer) do
-          Dry::View::Renderer.new(
-            [Dry::View::Path.new(SPEC_ROOT.join('fixtures/templates_override'))],
-            format: 'html'
-          )
-        end
-
-        it 'renders correctly' do
-          new_part = part.new(value: 'new value', renderer: new_renderer)
-          expect(part._render(:hello)).to eql('<h1>Partial hello</h1>')
-          expect(new_part._render(:hello)).to eql('<h1>Partial new hello</h1>')
-        end
-      end
-    end
-
     describe '#to_s' do
       before do
         allow(value).to receive(:to_s).and_return 'to_s on the value'
@@ -70,6 +37,16 @@ RSpec.describe Dry::View::Part do
 
       it 'delegates to the wrapped value' do
         expect(part.to_s).to eq 'to_s on the value'
+      end
+    end
+
+    describe '#new' do
+      it 'preserves decorator, renderer, and context' do
+        new_part = part.new(value: 'new value')
+
+        expect(new_part._decorator).to eql part._decorator
+        expect(new_part._renderer).to eql part._renderer
+        expect(new_part._context).to eql part._context
       end
     end
 


### PR DESCRIPTION
Resolves #45, closes #51

This PR implements decorated part attributes, following the "decoration from the inside" approach that I described in @GustavoCaso's attempt a  https://github.com/dry-rb/dry-view/pull/51#issuecomment-347048807.

Overview of the approach:

1. Part classes declare via `.decorate` which of their value's attributes they'd like decorated by part classes. The intended final API would be something like this:
    ```ruby
    class ArticlePart < Dry::View::Part
      # Explicit decoration by providing class names:
      decorate :author, as: AuthorPart
      decorate :comments, as: CommentPart

      # Or if your app provides a custom decorator that does implicit wrapping based on name, this won't even be necessary:
      decorate :author, :comments
    end
    ```
2. Part classes expect a `decorator:` option to be provided to them when they're initialized
3. This decorator is called with each of the part's decorated attributes and it stores a hash of the results
4. When calling methods on the initialized part object, the decorated attributes hash is checked for a matching key and that value is returned if present.

I began this PR with basic support added to `Dry::View::Part` along with a simple integration test.

Together, this is hopefully enough to demonstrate the overall approach and for us to decide if we're happy to continue (@solnic, @GustavoCaso — what do you think?).

To do:

- [x] Decorator needs to pass `decorator: self` when initializing parts (this is critical for the same decorator to be passed all the way down the tree of decorated attributes when a part is initialized — right now in this simple first pass we're just relying on the default value for the `decorator:` option on `Part#initialize`)
- [x] Proper support for decorating attributes that are collections (i.e. mimic the behaviour we have for `Dry::View::Controller.expose` with collections
- [x] Change `Dry::View::Part.decorate` to accept multiple attributes (useful for when no per-attribute options are required)
- [x] ~~Probably build up a custom object for holding the declared decorated attributes, rather than just a hash?~~
- [x] Tests for all the different use cases