### PR TITLE
Decorate truthy part attributes only

### DIFF
--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -90,13 +90,18 @@ module Dry
 
       def _resolve_decorated_attribute(name)
         _decorated_attributes.fetch(name) {
-          _decorated_attributes[name] = _decorator.(
-            name,
-            _value.__send__(name),
-            renderer: _renderer,
-            context: _context,
-            **self.class.decorated_attributes[name],
-          )
+          attribute = _value.__send__(name)
+
+          _decorated_attributes[name] =
+            if attribute # Decorate truthy attributes only
+              _decorator.(
+                name,
+                attribute,
+                renderer: _renderer,
+                context: _context,
+                **self.class.decorated_attributes[name],
+              )
+            end
         }
       end
     end

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'Part / Decorated attributes' do
           end
         }
 
-        it 'decorates exposures with the standard Dry::View::Part class' do
+        it 'decorates attributes with the standard Dry::View::Part class' do
           expect(article_part.author).to be_a Dry::View::Part
           expect(article_part.comments[0]).to be_a Dry::View::Part
         end
@@ -84,7 +84,7 @@ RSpec.describe 'Part / Decorated attributes' do
           end
         }
 
-        it 'decorates exposures with the standard Dry::View::Part class' do
+        it 'decorates attributes with the standard Dry::View::Part class' do
           expect(article_part.author).to be_a Dry::View::Part
           expect(article_part.comments[0]).to be_a Dry::View::Part
         end
@@ -117,7 +117,7 @@ RSpec.describe 'Part / Decorated attributes' do
         end
       }
 
-      it 'deorates exposures with the specified part class' do
+      it 'deorates attributes with the specified part class' do
         expect(article_part.author).to be_a Test::AuthorPart
         expect(article_part.comments[0]).to be_a Test::CommentPart
       end
@@ -176,7 +176,7 @@ RSpec.describe 'Part / Decorated attributes' do
       end
     end
 
-    it 'deorates exposures using the custom decorator' do
+    it 'deorates attributes using the custom decorator' do
       expect(article_part.author).to be_a Test::AuthorPart
       expect(article_part.comments[0]).to be_a Test::CommentPart
       expect(article_part.comments[0].author).to be_a Test::AuthorPart

--- a/spec/integration/part/decorated_attributes_spec.rb
+++ b/spec/integration/part/decorated_attributes_spec.rb
@@ -32,10 +32,14 @@ RSpec.describe 'Part / Decorated attributes' do
     end
   }
 
+  let (:author) {
+    author_class.new(name: 'Jane Doe')
+  }
+
   let(:article) {
     article_class.new(
       title: 'Hello world',
-      author: author_class.new(name: 'Jane Doe'),
+      author: author,
       comments: [
         comment_class.new(author: author_class.new(name: 'Sue Smith'), body: 'Great article')
       ]
@@ -63,6 +67,14 @@ RSpec.describe 'Part / Decorated attributes' do
           expect(article_part.author).to be_a Dry::View::Part
           expect(article_part.comments[0]).to be_a Dry::View::Part
         end
+
+        context 'falsey values' do
+          let(:author) { nil }
+
+          it 'does not decorate the attributes' do
+            expect(article_part.author).to be_nil
+          end
+        end
       end
 
       describe 'single declaration' do
@@ -75,6 +87,14 @@ RSpec.describe 'Part / Decorated attributes' do
         it 'decorates exposures with the standard Dry::View::Part class' do
           expect(article_part.author).to be_a Dry::View::Part
           expect(article_part.comments[0]).to be_a Dry::View::Part
+        end
+
+        context 'falsey values' do
+          let(:author) { nil }
+
+          it 'does not decorate the attributes' do
+            expect(article_part.author).to be_nil
+          end
         end
       end
     end
@@ -100,6 +120,14 @@ RSpec.describe 'Part / Decorated attributes' do
       it 'deorates exposures with the specified part class' do
         expect(article_part.author).to be_a Test::AuthorPart
         expect(article_part.comments[0]).to be_a Test::CommentPart
+      end
+
+      context 'falsey values' do
+        let(:author) { nil }
+
+        it 'does not decorate the attributes' do
+          expect(article_part.author).to be_nil
+        end
       end
     end
   end
@@ -152,6 +180,14 @@ RSpec.describe 'Part / Decorated attributes' do
       expect(article_part.author).to be_a Test::AuthorPart
       expect(article_part.comments[0]).to be_a Test::CommentPart
       expect(article_part.comments[0].author).to be_a Test::AuthorPart
+    end
+
+    context 'falsey values' do
+      let(:author) { nil }
+
+      it 'does not decorate the attributes' do
+        expect(article_part.author).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
This keeps the decoration behaviour in view parts consistent with the behaviour at the view controller level (where only truthy values are decorated). This allows `if my_part.some_attribute` checks inside template to work as expected.

Fixes #59