### PR TITLE
Add Dry::View::Rendered to carry template output and locals (wrapped in view parts)

### DIFF
--- a/lib/dry/view/exposures.rb
+++ b/lib/dry/view/exposures.rb
@@ -40,11 +40,16 @@ module Dry
         self.class.new(bound_exposures)
       end
 
-      def locals(input)
+      def call(input)
         tsort.each_with_object({}) { |name, memo|
-          memo[name] = self[name].(input, memo) if exposures.key?(name)
-        }.each_with_object({}) { |(name, val), memo|
-          memo[name] = val unless self[name].private?
+          next unless exposure = self[name]
+
+          value = exposure.(input, memo)
+          value = yield(value, exposure) if block_given?
+
+          memo[name] = value
+        }.each_with_object({}) { |(name, value), memo|
+          memo[name] = value unless self[name].private?
         }
       end
 

--- a/lib/dry/view/rendered.rb
+++ b/lib/dry/view/rendered.rb
@@ -1,0 +1,26 @@
+require 'dry/equalizer'
+
+module Dry
+  module View
+    class Rendered
+      include Dry::Equalizer(:output, :locals)
+
+      attr_reader :output
+      attr_reader :locals
+
+      def initialize(output:, locals:)
+        @output = output
+        @locals = locals
+      end
+
+      def [](name)
+        locals[name]
+      end
+
+      def to_s
+        output
+      end
+      alias_method :to_str, :to_s
+    end
+  end
+end

--- a/spec/integration/decorator_spec.rb
+++ b/spec/integration/decorator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'decorator' do
         expose :ordinary
       end.new
 
-      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
+      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing').to_s).to eql(
         '<p>Custom part wrapping many things</p><p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
       )
     end
@@ -47,7 +47,7 @@ RSpec.describe 'decorator' do
         expose :ordinary
       end.new
 
-      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
+      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing').to_s).to eql(
         '<p>Custom part wrapping many things</p><p>Custom part wrapping many things</p><p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
       )
     end
@@ -72,7 +72,7 @@ RSpec.describe 'decorator' do
         expose :customs, :custom, :ordinary
       end.new
 
-      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing')).to eql(
+      expect(vc.(customs: ['many things'], custom: 'custom thing', ordinary: 'ordinary thing').to_s).to eql(
         '<p>Custom part wrapping many things</p><p>Custom part wrapping custom thing</p><p>ordinary thing</p>'
       )
     end

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe 'dry-view' do
         config.template = 'users'
         config.default_format = :html
       end
+
+      expose :users do
+        [
+          { name: 'Jane', email: 'jane@doe.org' },
+          { name: 'Joe', email: 'joe@doe.org' }
+        ]
+      end
     end
   end
 
@@ -17,12 +24,7 @@ RSpec.describe 'dry-view' do
   it 'renders within a layout and makes the provided context available everywhere' do
     vc = vc_class.new
 
-    users = [
-      { name: 'Jane', email: 'jane@doe.org' },
-      { name: 'Joe', email: 'joe@doe.org' }
-    ]
-
-    expect(vc.(context: context, locals: {users: users})).to eql(
+    expect(vc.(context: context).to_s).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" /></body></html>'
     )
   end
@@ -34,37 +36,15 @@ RSpec.describe 'dry-view' do
       end
     end.new
 
-    users = [
-      { name: 'Jane', email: 'jane@doe.org' },
-      { name: 'Joe', email: 'joe@doe.org' }
-    ]
-
-    expect(vc.(context: context, locals: {users: users})).to eql(
+    expect(vc.(context: context).to_s).to eql(
       '<div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" />'
-    )
-  end
-
-  it 'renders a view without locals' do
-    vc = Class.new(vc_class) do
-      configure do |config|
-        config.template = 'empty'
-      end
-    end.new
-
-    expect(vc.(context: context, locals: {})).to eq(
-      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><p>This is a view with no locals.</p></body></html>'
     )
   end
 
   it 'renders a view with an alternative format and engine' do
     vc = vc_class.new
 
-    users = [
-      { name: 'Jane', email: 'jane@doe.org' },
-      { name: 'Joe', email: 'joe@doe.org' }
-    ]
-
-    expect(vc.(context: context, locals: {users: users}, format: 'txt').strip).to eql(
+    expect(vc.(context: context, format: 'txt').to_s.strip).to eql(
       "# dry-view rocks!\n\n* Jane (jane@doe.org)\n* Joe (joe@doe.org)"
     )
   end
@@ -76,12 +56,7 @@ RSpec.describe 'dry-view' do
       end
     end.new
 
-    users = [
-      { name: 'Jane', email: 'jane@doe.org' },
-      { name: 'Joe', email: 'joe@doe.org' }
-    ]
-
-    expect(vc.(context: context, locals: {users: users})).to eq(
+    expect(vc.(context: context).to_s).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><h1>OVERRIDE</h1><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div></body></html>'
     )
   end
@@ -93,12 +68,7 @@ RSpec.describe 'dry-view' do
       end
     end.new
 
-    users = [
-      { name: 'Jane', email: 'jane@doe.org' },
-      { name: 'Joe', email: 'joe@doe.org' }
-    ]
-
-    expect(vc.(context: context, locals: {users: users})).to eq(
+    expect(vc.(context: context).to_s).to eq(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><div class="users"><div class="box"><h2>Nombre</h2>Jane</div><div class="box"><h2>Nombre</h2>Joe</div></div></body></html>'
     )
   end
@@ -123,9 +93,20 @@ RSpec.describe 'dry-view' do
     end
 
     it 'renders within a parent class layout using provided context' do
-      vc = child_view.new
+      vc = Class.new(vc_class) do
+        configure do |config|
+          config.template = 'tasks'
+        end
 
-      expect(vc.(context: context, locals: { tasks: [{ title: 'one' }, { title: 'two' }] })).to eql(
+        expose :tasks do
+          [
+            {title: 'one'},
+            {title: 'two'},
+          ]
+        end
+      end.new
+
+      expect(vc.(context: context).to_s).to eql(
         '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><ol><li>one</li><li>two</li></ol></body></html>'
       )
     end

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -6,20 +6,24 @@ RSpec.describe Dry::View::Controller do
         config.layout = 'app'
         config.template = 'user'
       end
+
+      expose :user do
+        {name: 'Jane'}
+      end
+
+      expose :header do
+        {title: 'User'}
+      end
     end.new
   }
 
-  let(:page) do
+  let(:context) do
     double(:page, title: 'Test')
-  end
-
-  let(:options) do
-    { context: page, locals: { user: { name: 'Jane' }, header: { title: 'User' } } }
   end
 
   describe '#call' do
     it 'renders template within the layout' do
-      expect(controller.(options)).to eql(
+      expect(controller.(context: context).to_s).to eql(
         '<!DOCTYPE html><html><head><title>Test</title></head><body><h1>User</h1><p>Jane</p></body></html>'
       )
     end
@@ -31,7 +35,7 @@ RSpec.describe Dry::View::Controller do
         end
       end.new
 
-      expect { controller.(options) }.to raise_error Dry::View::Controller::UndefinedTemplateError
+      expect { controller.(context: context) }.to raise_error Dry::View::Controller::UndefinedTemplateError
     end
   end
 
@@ -75,7 +79,7 @@ RSpec.describe Dry::View::Controller do
     end
 
     it 'are passed to renderer' do
-      expect(controller.(context: context)).to eql(
+      expect(controller.(context: context).to_s).to eq(
         '<form action="/people" method="post"><input type="text" name="name" /></form>'
       )
     end

--- a/spec/unit/rendered_spec.rb
+++ b/spec/unit/rendered_spec.rb
@@ -1,0 +1,36 @@
+require 'dry/view/rendered'
+
+RSpec.describe Dry::View::Rendered do
+  subject(:rendered) {
+    described_class.new(
+      output: "rendered template output",
+      locals: {
+        user: {name: "Jane"},
+      },
+    )
+  }
+
+  describe "#to_s" do
+    it "returns the rendered output" do
+      expect(rendered.to_s).to eq "rendered template output"
+    end
+  end
+
+  describe "#to_str" do
+    it "returns the rendered output" do
+      expect(rendered.to_str).to eq "rendered template output"
+    end
+  end
+
+  describe "#locals" do
+    it "returns the locals hash" do
+      expect(rendered.locals).to eql({user: {name: "Jane"}})
+    end
+  end
+
+  describe "#[]" do
+    it "returns the named local" do
+      expect(rendered[:user]).to eql(name: "Jane")
+    end
+  end
+end


### PR DESCRIPTION
Here's what you can do now:

```ruby
# Get your view controller
vc = MyView.new

# Call it and a "Rendered" object
rendered = vc.(users: users)
# => #<Dry::View::Rendered ...>

# Which converts to a string of the rendered template output (both explicit #to_s and implicit #to_str supported)
rendered.to_s
# => "<!DOCTYPE html><html>... "

# And also carries a hash of the locals passed to the view from the VC's exposures
rendered.locals.keys
# => [:users, ...]

# Which you can access by name. Note that the locals are all wrapped in their view parts
rendered[:users]
# => #<Dry::View::Part _name=:users _value=[...]>
```

These locals are now wrapped in view parts as early as possible, including when they're made available as exposure dependencies. This means it's possible to take advantage of view-specific logic while building up the full set of locals.

Providing exposures wrapped in view parts as part of Dry::View::Rendered also opens up interesting possibilities for accessing specific _aspects_ of a rendered view, not just the whole rendered template string.

Resolves #64, resolves #69