### PR TITLE
Add option to make exposure available to layout

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -25,6 +25,7 @@ module Dry
 
       setting :paths
       setting :layout, false
+      setting :exposure_in_layout, false
       setting :template
       setting :default_format, :html
       setting :renderer_options, DEFAULT_RENDERER_OPTIONS do |options|
@@ -118,7 +119,8 @@ module Dry
         output = renderer.template(template_path, template_scope(renderer, context, locals))
 
         if layout?
-          output = renderer.template(layout_path, layout_scope(renderer, context)) { output }
+          layout_locals = config.exposure_in_layout ? locals : EMPTY_LOCALS
+          output = renderer.template(layout_path, layout_scope(renderer, context, layout_locals)) { output }
         end
 
         Rendered.new(output: output, locals: locals)
@@ -140,8 +142,8 @@ module Dry
         !!config.layout
       end
 
-      def layout_scope(renderer, context)
-        scope(renderer.chdir(layout_dir), context)
+      def layout_scope(renderer, context, locals = EMPTY_LOCALS)
+        scope(renderer.chdir(layout_dir), context, locals)
       end
 
       def template_scope(renderer, context, locals)

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -138,7 +138,7 @@ module Dry
 
       def layout_locals(locals)
         locals.each_with_object({}) do |(key, value), layout_locals|
-          layout_locals[key] = value if exposures[key].layout?
+          layout_locals[key] = value if exposures[key].for_layout?
         end
       end
 

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -25,7 +25,6 @@ module Dry
 
       setting :paths
       setting :layout, false
-      setting :exposure_in_layout, false
       setting :template
       setting :default_format, :html
       setting :renderer_options, DEFAULT_RENDERER_OPTIONS do |options|
@@ -119,8 +118,7 @@ module Dry
         output = renderer.template(template_path, template_scope(renderer, context, locals))
 
         if layout?
-          layout_locals = config.exposure_in_layout ? locals : EMPTY_LOCALS
-          output = renderer.template(layout_path, layout_scope(renderer, context, layout_locals)) { output }
+          output = renderer.template(layout_path, layout_scope(renderer, context, layout_locals(locals))) { output }
         end
 
         Rendered.new(output: output, locals: locals)
@@ -135,6 +133,12 @@ module Dry
           else
             value
           end
+        end
+      end
+
+      def layout_locals(locals)
+        locals.each_with_object({}) do |(key, value), layout_locals|
+          layout_locals[key] = value if exposures[key].layout?
         end
       end
 

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -44,6 +44,10 @@ module Dry
         end
       end
 
+      def layout?
+        options.fetch(:layout) { false }
+      end
+
       def decorate?
         options.fetch(:decorate) { true }
       end

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -44,7 +44,7 @@ module Dry
         end
       end
 
-      def layout?
+      def for_layout?
         options.fetch(:layout) { false }
       end
 

--- a/spec/fixtures/templates/layouts/app_with_users.html.slim
+++ b/spec/fixtures/templates/layouts/app_with_users.html.slim
@@ -4,5 +4,5 @@ html
     title == title
   body
     p
-      = "#{users.count} users"
+      = "#{users_count} users"
     == yield

--- a/spec/fixtures/templates/layouts/app_with_users.html.slim
+++ b/spec/fixtures/templates/layouts/app_with_users.html.slim
@@ -1,0 +1,8 @@
+doctype html
+html
+  head
+    title == title
+  body
+    p
+      = "#{users.count} users"
+    == yield

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -438,4 +438,27 @@ RSpec.describe 'exposures' do
     expect(child.(input).locals).to include(:users, :users_count, :child_expose)
     expect(child.(input).locals).not_to include(:prefix)
   end
+
+  it 'makes exposures available to layout' do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = 'app_with_users'
+        config.exposure_in_layout = true
+        config.template = 'users'
+        config.default_format = :html
+      end
+
+      expose :users
+    end.new
+
+    users = [
+      { name: 'Jane', email: 'jane@doe.org' },
+      { name: 'Joe', email: 'joe@doe.org' }
+    ]
+
+    expect(vc.(users: users, context: context).to_s).to eql(
+      '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><p>2 users</p><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" /></body></html>'
+    )
+  end
 end

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -444,10 +444,11 @@ RSpec.describe 'exposures' do
       configure do |config|
         config.paths = SPEC_ROOT.join('fixtures/templates')
         config.layout = 'app_with_users'
-        config.exposure_in_layout = true
         config.template = 'users'
         config.default_format = :html
       end
+
+      expose :users_count, layout: true
 
       expose :users
     end.new
@@ -457,7 +458,7 @@ RSpec.describe 'exposures' do
       { name: 'Joe', email: 'joe@doe.org' }
     ]
 
-    expect(vc.(users: users, context: context).to_s).to eql(
+    expect(vc.(users: users, users_count: users.size, context: context).to_s).to eql(
       '<!DOCTYPE html><html><head><title>dry-view rocks!</title></head><body><p>2 users</p><div class="users"><table><tbody><tr><td>Jane</td><td>jane@doe.org</td></tr><tr><td>Joe</td><td>joe@doe.org</td></tr></tbody></table></div><img src="mindblown.jpg" /></body></html>'
     )
   end


### PR DESCRIPTION
Fix https://github.com/dry-rb/dry-view/issues/84

@timriley I opened this PR so we can start a discussion of the best way to allow layout access exposures.

This implementation uses a new setting `exposure_in_layout`

Based on that setting it will pass the locals to the layout or not.

I think this is not a bad idea, but I guess it could get out of hand depending on the size of locals since it would be in both `layout_scope` and `template_scope` and maybe would affect the performance of the library

I thought of having an exposure option base implementation where the user, can decide with exposure will be available in the layout.

```ruby
vc = Class.new(Dry::View::Controller) do
  configure do |config|
    config.paths = SPEC_ROOT.join('fixtures/templates')
    config.layout = 'app_with_users'
    config.template = 'users'
    config.default_format = :html
  end
  
  expose :users, layout: true
end.new
```

Of course, this implementation will require more changes in the codebase, but I wanted to open the discussion before starting to code.

Look forward to hearing your thoughts.
