### PR TITLE
Leave exposure values undecorated when exposures specify `decorate: false`

### DIFF
--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -128,7 +128,11 @@ module Dry
 
       def locals(renderer, context, input)
         exposures.(input) do |value, exposure|
-          decorate_local(renderer, context, exposure.name, value, **exposure.options)
+          if exposure.decorate?
+            decorate_local(renderer, context, exposure.name, value, **exposure.options)
+          else
+            value
+          end
         end
       end
 

--- a/lib/dry/view/exposure.rb
+++ b/lib/dry/view/exposure.rb
@@ -44,6 +44,10 @@ module Dry
         end
       end
 
+      def decorate?
+        options.fetch(:decorate) { true }
+      end
+
       def private?
         options.fetch(:private) { false }
       end

--- a/spec/integration/controller/locals_spec.rb
+++ b/spec/integration/controller/locals_spec.rb
@@ -1,0 +1,35 @@
+require "dry/view/controller"
+require "dry/view/part"
+
+RSpec.describe "locals" do
+
+  specify "locals are decorated with parts by default" do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.template = "greeting"
+      end
+
+      expose :greeting
+    end.new
+
+    local = vc.(greeting: "Hello").locals[:greeting]
+
+    expect(local).to be_a(Dry::View::Part)
+  end
+
+  specify "locals are not decorated if their exposure is marked as `decorate: false`" do
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.template = "greeting"
+      end
+
+      expose :greeting, decorate: false
+    end.new
+
+    local = vc.(greeting: "Hello").locals[:greeting]
+
+    expect(local).to eq "Hello"
+  end
+end

--- a/spec/unit/exposure_spec.rb
+++ b/spec/unit/exposure_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe Dry::View::Exposure do
       end
     end
 
+    describe "#decorate?" do
+      it "is true by default" do
+        expect(exposure.decorate?).to eq true
+      end
+
+      it "can be set on initialization" do
+        expect(described_class.new(:hello, decorate: false).decorate?).to eq false
+      end
+    end
+
     describe "#private?" do
       it "is false by default" do
         expect(exposure).not_to be_private


### PR DESCRIPTION
Resolves #83 
