### PR TITLE
Add base Context class with support for decorated attributes

### DIFF
--- a/lib/dry/view/context.rb
+++ b/lib/dry/view/context.rb
@@ -1,0 +1,59 @@
+module Dry
+  module View
+    class Context
+      attr_reader :_options, :_part_builder, :_renderer
+
+      def initialize(part_builder: nil, renderer: nil, **options)
+        @_part_builder = part_builder
+        @_renderer = renderer
+        @_options = options
+      end
+
+      def bind(part_builder:, renderer:)
+        self.class.new(
+          **_options.merge(
+            part_builder: part_builder,
+            renderer: renderer,
+          )
+        )
+      end
+
+      def bound?
+        !!(_part_builder && _renderer)
+      end
+
+      def self.decorate(*names, **options)
+        mod = DecoratedAttributes.new(names) do
+          names.each do |name|
+            define_method name do
+              attribute = super()
+
+              return attribute unless bound? || !attribute
+
+              _part_builder.(
+                name: name,
+                value: attribute,
+                renderer: _renderer,
+                context: self,
+                **options,
+              )
+            end
+          end
+        end
+
+        prepend mod
+      end
+
+      class DecoratedAttributes < Module
+        def initialize(names, &block)
+          @names = names
+          super(&block)
+        end
+
+        def inspect
+          %(#<#{self.class.name}#{@names.inspect}>)
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/view/controller.rb
+++ b/lib/dry/view/controller.rb
@@ -2,6 +2,7 @@ require 'dry/configurable'
 require 'dry/equalizer'
 require 'dry/inflector'
 
+require_relative 'context'
 require_relative 'exposures'
 require_relative 'part_builder'
 require_relative 'path'
@@ -15,7 +16,7 @@ module Dry
       UndefinedTemplateError = Class.new(StandardError)
 
       DEFAULT_LAYOUTS_DIR = 'layouts'.freeze
-      DEFAULT_CONTEXT = Object.new.freeze
+      DEFAULT_CONTEXT = Context.new
       DEFAULT_RENDERER_OPTIONS = {default_encoding: 'utf-8'.freeze}.freeze
       EMPTY_LOCALS = {}.freeze
 
@@ -112,6 +113,7 @@ module Dry
         raise UndefinedTemplateError, "no +template+ configured" unless template_path
 
         renderer = self.class.renderer(format)
+        context = context.bind(part_builder: part_builder, renderer: renderer)
 
         locals = locals(renderer.chdir(template_path), context, input)
 

--- a/spec/fixtures/integration/context/decorated_attributes.html.slim
+++ b/spec/fixtures/integration/context/decorated_attributes.html.slim
@@ -1,0 +1,3 @@
+== assets.image_tag("hello.png")
+.user
+  == user.image_tag

--- a/spec/integration/context_spec.rb
+++ b/spec/integration/context_spec.rb
@@ -1,0 +1,65 @@
+require "dry/view/context"
+require "dry/view/controller"
+require "dry/view/part"
+
+RSpec.describe "Context" do
+  it "Provides decorated attributes for use in templates and parts" do
+    module Test
+      class Assets
+        def [](path)
+          "hashed/path/to/#{path}"
+        end
+      end
+
+      class Context < Dry::View::Context
+        attr_reader :assets
+        decorate :assets
+
+        def initialize(assets:, **options)
+          @assets = assets
+          super
+        end
+      end
+
+      module Parts
+        class Assets < Dry::View::Part
+          def image_tag(path)
+            <<~HTML
+              <img src="#{value[path]}">
+            HTML
+          end
+        end
+
+        class User < Dry::View::Part
+          def image_tag
+            value[:image_url] || context.assets.image_tag("default.png")
+          end
+        end
+      end
+    end
+
+    vc = Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = FIXTURES_PATH.join("integration/context")
+        config.template = "decorated_attributes"
+        config.part_namespace = Test::Parts
+      end
+
+      expose :user
+    end.new
+
+    context = Test::Context.new(assets: Test::Assets.new)
+
+    output = vc.(
+      user: {image_url: nil},
+      context: context,
+    ).to_s
+
+    expect(output.gsub("\n", "")).to eq <<~HTML.gsub("\n", "")
+      <img src="hashed/path/to/hello.png">
+      <div class="user">
+      <img src="hashed/path/to/default.png">
+      </div>
+    HTML
+  end
+end

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -1,8 +1,19 @@
+require 'dry/view/context'
 require 'dry/view/controller'
 require 'dry/view/part'
 
 RSpec.describe 'exposures' do
-  let(:context) { Struct.new(:title, :assets).new('dry-view rocks!', -> input { "#{input}.jpg" }) }
+  let(:context) {
+    Class.new(Dry::View::Context) do
+      def title
+        'dry-view rocks!'
+      end
+
+      def assets
+        -> input { "#{input}.jpg" }
+      end
+    end.new
+  }
 
   it 'uses exposures with blocks to build view locals' do
     vc = Class.new(Dry::View::Controller) do

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -17,9 +17,17 @@ RSpec.describe 'dry-view' do
     end
   end
 
-  let(:context) do
-    Struct.new(:title, :assets).new('dry-view rocks!', -> input { "#{input}.jpg" })
-  end
+  let(:context) {
+    Class.new(Dry::View::Context) do
+      def title
+        'dry-view rocks!'
+      end
+
+      def assets
+        -> input { "#{input}.jpg" }
+      end
+    end.new
+  }
 
   it 'renders within a layout and makes the provided context available everywhere' do
     vc = vc_class.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ begin
 rescue LoadError; end
 
 SPEC_ROOT = Pathname(__FILE__).dirname
+FIXTURES_PATH = SPEC_ROOT.join("fixtures")
 
 require 'erb'
 require 'slim'

--- a/spec/unit/context_spec.rb
+++ b/spec/unit/context_spec.rb
@@ -1,0 +1,58 @@
+require "dry/view/context"
+require "dry/view/part"
+require "dry/view/part_builder"
+
+RSpec.describe Dry::View::Context do
+  let(:context_class) {
+    Class.new(Dry::View::Context) do
+      attr_reader :assets
+
+      decorate :assets, :invalid_attribute
+
+      def initialize(assets:, **options)
+        @assets = assets
+        super
+      end
+    end
+  }
+
+  let(:assets) { double(:assets) }
+  let(:renderer) { double(:renderer) }
+  let(:part_builder) { Dry::View::PartBuilder.new }
+
+  it "provides a helpful #inspect on the generated decorated attributes module" do
+    expect(context_class.ancestors[0].inspect).to eq "#<Dry::View::Context::DecoratedAttributes[:assets, :invalid_attribute]>"
+  end
+
+  context "unbound" do
+    subject(:context) { context_class.new(assets: assets) }
+
+    it { is_expected.not_to be_bound }
+
+    it "returns its attributes" do
+      expect(context.assets).to eql assets
+    end
+
+    it "raises NoMethodError when an invalid attribute is decorated" do
+      expect { context.invalid_attribute }.to raise_error(NoMethodError)
+    end
+  end
+
+  context "bound" do
+    subject(:context) {
+      context_class.new(assets: assets).
+        bind(renderer: renderer, part_builder: part_builder)
+    }
+
+    it { is_expected.to be_bound }
+
+    it "returns its assets decorated in view parts" do
+      expect(context.assets).to be_a Dry::View::Part
+      expect(context.assets.value).to eql assets
+    end
+
+    it "raises NoMethodError when an invalid attribute is decorated" do
+      expect { context.invalid_attribute }.to raise_error(NoMethodError)
+    end
+  end
+end


### PR DESCRIPTION
Having the context object provide a baseline rendering context across all templates is helpful, but until now the context object was never able to vend view parts. This I feel has been a real shortcoming, since view parts are where we can ideally put so much of our view logic.

This PR attempts to address this (and resolves #66).

Here's how a context object might look now.

```ruby
class MyContext < Dry::View::Context
  attr_reader :assets
  decorate :assets

  def initialize(assets:, **options)
    @assets = assets
    super
  end
end
```

It'd be neater still if you're auto-injecting:

```ruby
class MyContext < Dry::View::Context
  include Import["assets"]
  decorate :assets
end
```

So now, whenever `#assets` is accessed from the context (either in a template or from within a view part), it will be decorated in its own view part class.

So for an `assets` object whose job it is to map asset names to fully qualified recompiled asset paths (e.g. mapping `spacer.gif` to `assets/spacer-e9a8da62.gif`), previously we would've had to use it in templates like so:

```slim
img src=assets["spacer.gif"]
```

But now that we can have it decorated in a view part, we could provide a wider range of view-specific behaviours, e.g.

```slim
== assets.image_tag("spacer.gif")
```

(I'm sure there are more interesting possibilities than this, but you get the idea)

To make this happen, all context classes must now:

- Inherit from `Dry::View::Context`
- Have an `#initialize` that accepts keyword args only
- And from `#initialize`, they must call `super`

I'm providing the same `.decorate` API as we provide in the view part classes, but we need to take a different approach to make it work. Unlike the view part classes, which can rely on method_missing for decorated attributes, because the attributes are on the internal `value` object that the part object wraps, here we have to generate and prepend modules for each decorated attribute, because the attributes are already methods on the context object itself (i.e. method_missing won't help us).

This approach feels fine to me, it's the same kind of thing we do for e.g. `Dry::Core::Memoizable`.

One downside of this approach is that users can no longer provide any old object for the context (i.e. they now have to inherit from a `Dry::View::Context`), but I think given the very specific role of the context object, I think this is OK.

I've also had to add extra internal API to the context object in `#bind` and `#bound?`. We `#bind` the context to a rendering with each `#call` to a view controller, so we can give the context object everything it needs in order to be able to produce view parts. I'm using `#bound?` so that the prepended modules for the decorated attributes become no-ops if the context object isn't bound yet. TBH I'm not 100% sure this is necessary, but I like the idea of the context object not being _totally_ useless until its bound. Without this check, I'll have to raise exceptions if any of the decorated attributes are accessed on a non-bound context object.

So: any thoughts on this feature / overall implementation approach? /cc @solnic @GustavoCaso 