### PR TITLE
Add specs for using various features with different template engines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,10 @@ end
 
 group :test do
   gem "rack", ">= 2.0.6"
-  gem 'slim'
+
+  gem "erubi"
+  gem "haml", "~> 5.0"
+  gem 'slim', "~> 4.0"
 
   gem 'simplecov'
   gem 'codeclimate-test-reporter'

--- a/dry-view.gemspec
+++ b/dry-view.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_runtime_dependency "tilt", "~> 2.0"
+  spec.add_runtime_dependency "tilt", "~> 2.0", ">= 2.0.6"
   spec.add_runtime_dependency "dry-core", "~> 0.2"
   spec.add_runtime_dependency "dry-configurable", "~> 0.1"
   spec.add_runtime_dependency "dry-equalizer", "~> 0.2"

--- a/spec/fixtures/integration/template_engines/erb/method_with_yield.html.erb
+++ b/spec/fixtures/integration/template_engines/erb/method_with_yield.html.erb
@@ -1,0 +1,3 @@
+<%|= wrapper do %>
+  Yielded
+<%| end %>

--- a/spec/fixtures/integration/template_engines/erb/render_and_yield.html.erb
+++ b/spec/fixtures/integration/template_engines/erb/render_and_yield.html.erb
@@ -1,0 +1,3 @@
+<%|= render(:wrapper) do %>
+  Yielded
+<%| end %>

--- a/spec/fixtures/integration/template_engines/erb/shared/_wrapper.html.erb
+++ b/spec/fixtures/integration/template_engines/erb/shared/_wrapper.html.erb
@@ -1,0 +1,1 @@
+<wrapper><%= yield %></wrapper>

--- a/spec/fixtures/integration/template_engines/haml/method_with_yield.html.haml
+++ b/spec/fixtures/integration/template_engines/haml/method_with_yield.html.haml
@@ -1,0 +1,4 @@
+= wrapper do
+  - capture_haml do
+    :plain
+      Yielded

--- a/spec/fixtures/integration/template_engines/haml/render_and_yield.html.haml
+++ b/spec/fixtures/integration/template_engines/haml/render_and_yield.html.haml
@@ -1,0 +1,5 @@
+= render(:wrapper) do
+  - yielded = capture_haml do
+    :plain
+      Yielded
+  - haml_concat yielded

--- a/spec/fixtures/integration/template_engines/haml/shared/_wrapper.html.haml
+++ b/spec/fixtures/integration/template_engines/haml/shared/_wrapper.html.haml
@@ -1,0 +1,2 @@
+%wrapper
+  - yield

--- a/spec/fixtures/integration/template_engines/slim/method_with_yield.html.slim
+++ b/spec/fixtures/integration/template_engines/slim/method_with_yield.html.slim
@@ -1,0 +1,2 @@
+== wrapper do
+  | Yielded

--- a/spec/fixtures/integration/template_engines/slim/render_and_yield.html.slim
+++ b/spec/fixtures/integration/template_engines/slim/render_and_yield.html.slim
@@ -1,0 +1,2 @@
+== render(:wrapper) do
+  | Yielded

--- a/spec/fixtures/integration/template_engines/slim/shared/_wrapper.html.slim
+++ b/spec/fixtures/integration/template_engines/slim/shared/_wrapper.html.slim
@@ -1,0 +1,2 @@
+wrapper
+  == yield

--- a/spec/integration/template_engines/erubi_spec.rb
+++ b/spec/integration/template_engines/erubi_spec.rb
@@ -1,0 +1,43 @@
+require "erubi"
+require "erubi/capture_end"
+
+require "dry/view/context"
+require "dry/view/controller"
+
+RSpec.describe "Template engines / erb (via erubi)" do
+  let(:base_vc) {
+    Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = FIXTURES_PATH.join("integration/template_engines/erb")
+        config.renderer_options = {engine_class: Erubi::CaptureEndEngine}
+      end
+    end
+  }
+
+  it "supports partials that yield" do
+    vc = Class.new(base_vc) do
+      configure do |config|
+        config.template = "render_and_yield"
+      end
+    end.new
+
+    expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
+  end
+
+  it "supports context methods that yield" do
+    context = Class.new(Dry::View::Context) do
+      def wrapper
+        "<wrapper>#{yield}</wrapper>"
+      end
+    end.new
+
+    vc = Class.new(base_vc) do
+      configure do |config|
+        config.default_context = context
+        config.template = "method_with_yield"
+      end
+    end.new
+
+    expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
+  end
+end

--- a/spec/integration/template_engines/haml_spec.rb
+++ b/spec/integration/template_engines/haml_spec.rb
@@ -1,0 +1,42 @@
+require "haml"
+require "dry/view/context"
+require "dry/view/controller"
+
+RSpec.describe "Template engines / haml" do
+  let(:base_vc) {
+    Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = FIXTURES_PATH.join("integration/template_engines/haml")
+      end
+    end
+  }
+
+  it "supports partials that yield" do
+    vc = Class.new(base_vc) do
+      configure do |config|
+        config.template = "render_and_yield"
+      end
+    end.new
+
+    expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
+  end
+
+  it "supports methods that yield" do
+    context = Class.new(Dry::View::Context) do
+      include Haml::Helpers
+
+      def wrapper(&block)
+        "<wrapper>#{yield}</wrapper>"
+      end
+    end.new
+
+    vc = Class.new(base_vc) do
+      configure do |config|
+        config.default_context = context
+        config.template = "method_with_yield"
+      end
+    end.new
+
+    expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
+  end
+end

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -1,0 +1,40 @@
+require "slim"
+require "dry/view/context"
+require "dry/view/controller"
+
+RSpec.describe "Template engines / slim" do
+  let(:base_vc) {
+    Class.new(Dry::View::Controller) do
+      configure do |config|
+        config.paths = FIXTURES_PATH.join("integration/template_engines/slim")
+      end
+    end
+  }
+
+  it "supports partials that yield" do
+    vc = Class.new(base_vc) do
+      configure do |config|
+        config.template = "render_and_yield"
+      end
+    end.new
+
+    expect(vc.().to_s).to eq "<wrapper>Yielded</wrapper>"
+  end
+
+  it "supports context methods that yield" do
+    context = Class.new(Dry::View::Context) do
+      def wrapper
+        "<wrapper>#{yield}</wrapper>"
+      end
+    end.new
+
+    vc = Class.new(base_vc) do
+      configure do |config|
+        config.default_context = context
+        config.template = "method_with_yield"
+      end
+    end.new
+
+    expect(vc.().to_s).to eq "<wrapper>Yielded</wrapper>"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,13 +12,7 @@ rescue LoadError; end
 SPEC_ROOT = Pathname(__FILE__).dirname
 FIXTURES_PATH = SPEC_ROOT.join("fixtures")
 
-require 'erb'
 require 'slim'
-
-# Prefer plain ERB processor rather than erubis (which has problems on JRuby)
-require 'tilt'
-Tilt.register 'erb', Tilt::ERBTemplate
-
 require 'dry-view'
 
 module Test

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Dry::View::Controller do
     end
 
     it 'are passed to renderer' do
-      expect(controller.(context: context).to_s).to eq(
+      expect(controller.(context: context).to_s.gsub(/\n\s*/m, "")).to eq(
         '<form action="/people" method="post"><input type="text" name="name" /></form>'
       )
     end


### PR DESCRIPTION
This gives us a start at making sure our baseline features are all at least _possible_ to use from views rendered with the various popular template engines.