### PR TITLE
Cache template lookups in Path

### DIFF
--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -7,6 +7,16 @@ module Dry
 
       attr_reader :dir, :root
 
+      def self.cached_templates
+        @cached_templates ||= {}
+      end
+
+      def self.fetch_from_cache_or_store(key)
+        cached_templates.fetch(key) do
+          cached_templates[key] = yield
+        end
+      end
+
       def initialize(dir, options = {})
         @dir = Pathname(dir)
         @root = Pathname(options.fetch(:root, dir))
@@ -32,8 +42,10 @@ module Dry
 
       # Search for a template using a wildcard for the engine extension
       def template?(name, format)
-        glob = dir.join("#{name}.#{format}.*")
-        Dir[glob].first
+        unique_key = "#{dir}/#{name}.#{format}"
+        self.class.fetch_from_cache_or_store(unique_key) do
+          Dir[dir.join("#{name}.#{format}.*")].first
+        end
       end
     end
   end


### PR DESCRIPTION
Fix #94 

Thanks to @solnic for pointing out that the method `Path#template?` is very expensive. I decided to add some simple cached for storing the result of looking for template.

The performance results are positive after adding this functionality.

Before:

```bash
Warming up --------------------------------------
   action_controller     1.000  i/100ms
            dry-view     1.000  i/100ms
Calculating -------------------------------------
   action_controller      6.552  (± 0.0%) i/s -     33.000  in   5.038370s
            dry-view      1.289  (± 0.0%) i/s -      7.000  in   5.430740s

Comparison:
   action_controller:        6.6 i/s
            dry-view:        1.3 i/s - 5.08x  slower
```

After 

```bash
Warming up --------------------------------------
   action_controller     1.000  i/100ms
            dry-view     1.000  i/100ms
Calculating -------------------------------------
   action_controller      6.816  (± 0.0%) i/s -     35.000  in   5.136691s
            dry-view      3.750  (± 0.0%) i/s -     19.000  in   5.068494s

Comparison:
   action_controller:        6.8 i/s
            dry-view:        3.8 i/s - 1.82x  slower
```