### PR TITLE
add cache for part builder

### DIFF
--- a/lib/dry/view/helpers/caching.rb
+++ b/lib/dry/view/helpers/caching.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Dry
+  module View
+    module Helpers
+      module Caching
+        def self.included(base)
+          class << base
+            def fetch_from_cache_or_store(key)
+              cached_values.fetch(key) do
+                cached_values[key] = yield
+              end
+            end
+
+            def reset_cache
+              @cached_values = {}
+            end
+
+            private
+
+            def cached_values
+              @cached_values ||= {}
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -1,21 +1,13 @@
 require "pathname"
+require_relative 'helpers/caching'
 
 module Dry
   module View
     class Path
       include Dry::Equalizer(:dir, :root)
+      include Helpers::Caching
 
       attr_reader :dir, :root
-
-      def self.cached_templates
-        @cached_templates ||= {}
-      end
-
-      def self.fetch_from_cache_or_store(key)
-        cached_templates.fetch(key) do
-          cached_templates[key] = yield
-        end
-      end
 
       def initialize(dir, options = {})
         @dir = Pathname(dir)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,8 @@ RSpec.configure do |config|
 
   config.after do
     Test.remove_constants
+    Dry::View::Path.reset_cache
+    Dry::View::PartBuilder.reset_cache
   end
 end
 

--- a/spec/unit/helpers/caching_spec.rb
+++ b/spec/unit/helpers/caching_spec.rb
@@ -1,0 +1,46 @@
+require "dry/view/helpers/caching"
+
+RSpec.describe Dry::View::Helpers::Caching do
+  let(:cached) { spy(:cache) }
+
+  let(:klass) do
+    Class.new do
+      include Dry::View::Helpers::Caching
+
+      attr_reader :cached
+
+      def initialize(cached)
+        @cached = cached
+      end
+
+      def get(part)
+        self.class.fetch_from_cache_or_store(part) do
+          cached.stored
+          "Stored #{part}"
+        end
+      end
+    end.new(cached)
+  end
+
+  describe '#fetch_from_cache_or_store' do
+    it 'stores the result after first call and use the cache value the second time is called' do
+      klass.get('layout')
+      klass.get('layout')
+      expect(cached).to have_received(:stored).once
+    end
+
+    it 'returns the result from cache' do
+      result = klass.get('layout')
+      expect(result).to equal(klass.get('layout'))
+    end
+  end
+
+  describe '#reset_cache' do
+    it 'clears the cached values' do
+      klass.get('layout')
+      klass.class.reset_cache
+      klass.get('layout')
+      expect(cached).to have_received(:stored).twice
+    end
+  end
+end


### PR DESCRIPTION
@timriley @solnic the base branch is not master but `improve-Path#template-performance` 

Here is another PR that applies cache for `PartBuilder#call` method

Is not a huge win, but the performance has improved 😄 

**Before:**
```bash
Warming up --------------------------------------
   action_controller     1.000  i/100ms
            dry-view     1.000  i/100ms
Calculating -------------------------------------
   action_controller      6.420  (±15.6%) i/s -     32.000  in   5.031820s
            dry-view      3.644  (± 0.0%) i/s -     19.000  in   5.215104s

Comparison:
   action_controller:        6.4 i/s
            dry-view:        3.6 i/s - 1.76x  slower
```

**After:**
```bash
Warming up --------------------------------------
   action_controller     1.000  i/100ms
            dry-view     1.000  i/100ms
Calculating -------------------------------------
   action_controller      6.671  (± 0.0%) i/s -     34.000  in   5.097874s
            dry-view      4.236  (± 0.0%) i/s -     22.000  in   5.194745s

Comparison:
   action_controller:        6.7 i/s
            dry-view:        4.2 i/s - 1.58x  slower
```