### PR TITLE
Cache various lookups with Dry::Core::Cache

### DIFF
--- a/lib/dry/view/part_builder.rb
+++ b/lib/dry/view/part_builder.rb
@@ -1,9 +1,11 @@
+require 'dry/core/cache'
 require 'dry/equalizer'
 require_relative 'part'
 
 module Dry
   module View
     class PartBuilder
+      extend Dry::Core::Cache
       include Dry::Equalizer(:namespace)
 
       attr_reader :namespace
@@ -84,7 +86,9 @@ module Dry
         if name.is_a?(Class)
           name
         else
-          resolve_part_class(name: name, fallback_class: fallback_class)
+          fetch_or_store(namespace, name, fallback_class) do
+            resolve_part_class(name: name, fallback_class: fallback_class)
+          end
         end
       end
 

--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -1,8 +1,10 @@
 require "pathname"
+require "dry/core/cache"
 
 module Dry
   module View
     class Path
+      extend Dry::Core::Cache
       include Dry::Equalizer(:dir, :root)
 
       attr_reader :dir, :root
@@ -32,8 +34,10 @@ module Dry
 
       # Search for a template using a wildcard for the engine extension
       def template?(name, format)
-        glob = dir.join("#{name}.#{format}.*")
-        Dir[glob].first
+        fetch_or_store(root, dir, name, format) do
+          glob = dir.join("#{name}.#{format}.*")
+          Dir[glob].first
+        end
       end
     end
   end

--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -15,7 +15,9 @@ module Dry
       end
 
       def lookup(name, format)
-        template?(name, format) || template?("shared/#{name}", format) || !root? && chdir('..').lookup(name, format)
+        fetch_or_store(dir, root, name, format) do
+          template?(name, format) || template?("shared/#{name}", format) || !root? && chdir('..').lookup(name, format)
+        end
       end
 
       def chdir(dirname)
@@ -34,10 +36,8 @@ module Dry
 
       # Search for a template using a wildcard for the engine extension
       def template?(name, format)
-        fetch_or_store(root, dir, name, format) do
-          glob = dir.join("#{name}.#{format}.*")
-          Dir[glob].first
-        end
+        glob = dir.join("#{name}.#{format}.*")
+        Dir[glob].first
       end
     end
   end

--- a/lib/dry/view/renderer.rb
+++ b/lib/dry/view/renderer.rb
@@ -1,5 +1,6 @@
-require 'tilt'
+require 'dry/core/cache'
 require 'dry/equalizer'
+require 'tilt'
 
 module Dry
   module View
@@ -7,21 +8,18 @@ module Dry
       PARTIAL_PREFIX = "_".freeze
       PATH_DELIMITER = "/".freeze
 
+      extend Dry::Core::Cache
+
       include Dry::Equalizer(:paths, :format, :options)
 
       TemplateNotFoundError = Class.new(StandardError)
 
-      attr_reader :paths, :format, :options, :tilts
-
-      def self.tilts
-        @__engines__ ||= {}
-      end
+      attr_reader :paths, :format, :options
 
       def initialize(paths, format:, **options)
         @paths = paths
         @format = format
         @options = options
-        @tilts = self.class.tilts
       end
 
       def template(name, scope, &block)
@@ -64,8 +62,8 @@ module Dry
       end
 
       def tilt(path)
-        tilts.fetch(path) {
-          tilts[path] = Tilt.new(path, nil, **options)
+        fetch_or_store(:tilt, path, options) {
+          Tilt.new(path, nil, **options)
         }
       end
     end

--- a/lib/dry/view/scope_builder.rb
+++ b/lib/dry/view/scope_builder.rb
@@ -1,9 +1,11 @@
+require 'dry/core/cache'
 require 'dry/equalizer'
 require_relative 'scope'
 
 module Dry
   module View
     class ScopeBuilder
+      extend Dry::Core::Cache
       include Dry::Equalizer(:namespace)
 
       attr_reader :namespace
@@ -42,7 +44,9 @@ module Dry
         elsif name.is_a?(Class)
           name
         else
-          resolve_scope_class(name: name)
+          fetch_or_store(namespace, name) do
+            resolve_scope_class(name: name)
+          end
         end
       end
 


### PR DESCRIPTION
This PR uses `Dry::Core::Cache` to cache a few lookups that could otherwise be costly:

- Templates within paths
- Part classes within namespaces
- Scope classes within namespaces

@GustavoCaso I hope you don't mind me going ahead with this, I wanted to play around with what we could cache. And I figured we should use our existing caching helper from dry-core.

Before this change, we were ~5.5x slower than ActionController.

```
Warming up --------------------------------------
   action_controller     1.000  i/100ms
            dry-view     1.000  i/100ms
Calculating -------------------------------------
   action_controller      6.519  (± 0.0%) i/s -     33.000
            dry-view      1.171  (± 0.0%) i/s -      6.000

Comparison:
   action_controller:        6.5 i/s
            dry-view:        1.2 i/s - 5.56x slower
```

After this change, we're ~1.8x slower:

```
Warming up --------------------------------------
   action_controller     1.000  i/100ms
            dry-view     1.000  i/100ms
Calculating -------------------------------------
   action_controller      5.995  (±16.7%) i/s -     30.000
            dry-view      3.317  (± 0.0%) i/s -     17.000

Comparison:
   action_controller:        6.0 i/s
            dry-view:        3.3 i/s - 1.81x slower
```

Here's the latest profile diagram (run using Hotch and a new script I checked into the repo): `bundle exec ruby benchmarks/profile_controller.rb`

![profile](https://user-images.githubusercontent.com/3134/50326122-92c3e880-053c-11e9-9c9c-cc31d8c4d4f6.png)

So no more low hanging fruit, as far as I can tell? Would definitely appreciate any thoughts on taking things from here. 👋 @GustavoCaso @solnic 