### PR TITLE
Add custom Part#inspect including only name and value

### DIFF
--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -61,6 +61,10 @@ module Dry
         )
       end
 
+      def inspect
+        %(#<#{self.class.name} name=#{_name.inspect} value=#{_value.inspect}>)
+      end
+
       private
 
       def _context

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -63,6 +63,12 @@ RSpec.describe Dry::View::Part do
       end
     end
 
+    describe "#inspect" do
+      it "includes the clsas name, name, and value only" do
+        expect(part.inspect).to eq "#<Dry::View::Part name=:user value=#<Double :value>>"
+      end
+    end
+
     describe '#method_missing' do
       let(:value) { double(greeting: 'hello from value') }
 
@@ -82,7 +88,7 @@ RSpec.describe Dry::View::Part do
       end
     end
 
-    describe '#respond_to_missing?' do
+    describe '#respond_to' do
       let(:value) { double(greeting: 'hello from value') }
 
       it 'handles convenience methods' do


### PR DESCRIPTION
The output of Rendering#inspect may grow very large with both the context and inflector objects, so hide it from Part#inspect output, making parts easier to understand at a glance.

Resolves #70