### PR TITLE
Switch to hamlit-block and update haml specs to yield to blocks properly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ group :test do
   gem "rack", ">= 2.0.6"
 
   gem "erubi"
-  gem "haml", "~> 5.0"
+  gem "hamlit"
+  gem "hamlit-block"
   gem 'slim', "~> 4.0"
 
   gem 'simplecov'

--- a/spec/fixtures/integration/template_engines/haml/method_with_yield.html.haml
+++ b/spec/fixtures/integration/template_engines/haml/method_with_yield.html.haml
@@ -1,4 +1,0 @@
-= wrapper do
-  - capture_haml do
-    :plain
-      Yielded

--- a/spec/fixtures/integration/template_engines/haml/render_and_yield.html.haml
+++ b/spec/fixtures/integration/template_engines/haml/render_and_yield.html.haml
@@ -1,5 +1,0 @@
-= render(:wrapper) do
-  - yielded = capture_haml do
-    :plain
-      Yielded
-  - haml_concat yielded

--- a/spec/fixtures/integration/template_engines/haml/shared/_wrapper.html.haml
+++ b/spec/fixtures/integration/template_engines/haml/shared/_wrapper.html.haml
@@ -1,2 +1,0 @@
-%wrapper
-  - yield

--- a/spec/fixtures/integration/template_engines/hamlit/method_with_yield.html.haml
+++ b/spec/fixtures/integration/template_engines/hamlit/method_with_yield.html.haml
@@ -1,0 +1,3 @@
+= wrapper do
+  = "Yielded"
+

--- a/spec/fixtures/integration/template_engines/hamlit/render_and_yield.html.haml
+++ b/spec/fixtures/integration/template_engines/hamlit/render_and_yield.html.haml
@@ -1,0 +1,2 @@
+= render(:wrapper) do
+  = "Yielded"

--- a/spec/fixtures/integration/template_engines/hamlit/shared/_wrapper.html.haml
+++ b/spec/fixtures/integration/template_engines/hamlit/shared/_wrapper.html.haml
@@ -1,0 +1,2 @@
+%wrapper
+  = yield

--- a/spec/integration/template_engines/hamlit_spec.rb
+++ b/spec/integration/template_engines/hamlit_spec.rb
@@ -1,12 +1,12 @@
-require "haml"
+require "hamlit/block"
 require "dry/view/context"
 require "dry/view/controller"
 
-RSpec.describe "Template engines / haml" do
+RSpec.describe "Template engines / hamlit" do
   let(:base_vc) {
     Class.new(Dry::View::Controller) do
       configure do |config|
-        config.paths = FIXTURES_PATH.join("integration/template_engines/haml")
+        config.paths = FIXTURES_PATH.join("integration/template_engines/hamlit")
       end
     end
   }
@@ -23,8 +23,6 @@ RSpec.describe "Template engines / haml" do
 
   it "supports methods that yield" do
     context = Class.new(Dry::View::Context) do
-      include Haml::Helpers
-
       def wrapper(&block)
         "<wrapper>#{yield}</wrapper>"
       end


### PR DESCRIPTION
No more horrible hoop-jumping to capture/concat haml within blocks. With hamlit-block as the Haml template engine, we get sane yielding to blocks, just like Slim.