### PR TITLE
Backport chdir keeping options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+### Fixed
+
+- Backports fix to keep renderer options on chdir
+
+[889ac7b](https://github.com/dry-rb/dry-view/commit/889ac7b)
+
 # 0.5.3 / 2018-10-22
 
 ### Added

--- a/lib/dry/view/renderer.rb
+++ b/lib/dry/view/renderer.rb
@@ -46,7 +46,7 @@ module Dry
       def chdir(dirname)
         new_paths = paths.map { |path| path.chdir(dirname) }
 
-        self.class.new(new_paths, format: format)
+        self.class.new(new_paths, format: format, **options)
       end
 
       def lookup(name)


### PR DESCRIPTION
This backports 889ac7b to 0.5.x branch, because it caused a regression where it was not possible to render utf8 partials. Do you think it is a good idea to release a new version with it?

References #104 

**Important**: I have never tried to backport anything in GH. I have just branched from `0.5.3`, cherry-picked the commit and added a commit with update version/changelog. If there is a better way, please go ahead.

Thanks :)