### PR TITLE
Use default name for parts

### DIFF
--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -52,7 +52,7 @@ module Dry
         _value.to_s
       end
 
-      def new(klass = (self.class), name: (_name), value: (_value), **options)
+      def new(klass = (self.class), name: (self.class.name), value: (_value), **options)
         klass.new(
           name: name,
           value: value,


### PR DESCRIPTION
It simplifies its instantiation and, therefore, unit testing them:

```ruby
SomePart.new(value: SomeStruct)
```

WDYT @timriley ?

Further simplification could be made by using `value:` as standard argument, as opposed to keyword argument, but I don't consider it too critical.