### PR TITLE
Update all specs to use blockless form of writing config values

### DIFF
--- a/benchmarks/benchmark_controller.rb
+++ b/benchmarks/benchmark_controller.rb
@@ -28,12 +28,10 @@ class UsersController < ActionController::Base
 end
 
 class DryViewController < Dry::View::Controller
-  configure do |config|
-    config.paths = TEMPLATES_PATHS
-    config.layout = 'app'
-    config.template = 'users'
-    config.default_format = :html
-  end
+  config.paths = TEMPLATES_PATHS
+  config.layout = 'app'
+  config.template = 'users'
+  config.default_format = :html
 
   expose :users
 end

--- a/benchmarks/profile_controller.rb
+++ b/benchmarks/profile_controller.rb
@@ -13,11 +13,9 @@ TEMPLATE_LOCALS = { users: [
 ] }
 
 class Controller < Dry::View::Controller
-  configure do |config|
-    config.paths = TEMPLATES_PATHS
-    config.layout = 'app'
-    config.template = 'users'
-  end
+  config.paths = TEMPLATES_PATHS
+  config.layout = 'app'
+  config.template = 'users'
 
   expose :users
 end

--- a/spec/integration/context_spec.rb
+++ b/spec/integration/context_spec.rb
@@ -39,11 +39,9 @@ RSpec.describe "Context" do
     end
 
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = FIXTURES_PATH.join("integration/context")
-        config.template = "decorated_attributes"
-        config.part_namespace = Test::Parts
-      end
+      config.paths = FIXTURES_PATH.join("integration/context")
+      config.template = "decorated_attributes"
+      config.part_namespace = Test::Parts
 
       expose :user
     end.new

--- a/spec/integration/controller/locals_spec.rb
+++ b/spec/integration/controller/locals_spec.rb
@@ -4,10 +4,8 @@ require "dry/view/part"
 RSpec.describe "locals" do
   specify "locals are decorated with parts by default" do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.template = "greeting"
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.template = "greeting"
 
       expose :greeting
     end.new
@@ -19,10 +17,8 @@ RSpec.describe "locals" do
 
   specify "locals are not decorated if their exposure is marked as `decorate: false`" do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.template = "greeting"
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.template = "greeting"
 
       expose :greeting, decorate: false
     end.new

--- a/spec/integration/exposures_spec.rb
+++ b/spec/integration/exposures_spec.rb
@@ -17,12 +17,10 @@ RSpec.describe 'exposures' do
 
   it 'uses exposures with blocks to build view locals' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users'
+      config.default_format = :html
 
       expose :users do |users:|
         users.map { |user|
@@ -43,12 +41,10 @@ RSpec.describe 'exposures' do
 
   it 'gives the exposure blocks access to the view controller instance' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users'
+      config.default_format = :html
 
       attr_reader :prefix
 
@@ -76,12 +72,10 @@ RSpec.describe 'exposures' do
 
   it 'supports instance methods as exposures' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users'
+      config.default_format = :html
 
       expose :users
 
@@ -106,12 +100,10 @@ RSpec.describe 'exposures' do
 
   it 'passes matching input data if no proc or instance method is available' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users'
+      config.default_format = :html
 
       expose :users
     end.new
@@ -128,12 +120,10 @@ RSpec.describe 'exposures' do
 
   it 'using default values' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users'
+      config.default_format = :html
 
       expose :users, default: [{name: 'John', email: 'john@william.org'}]
     end.new
@@ -145,12 +135,10 @@ RSpec.describe 'exposures' do
 
   it 'having default values but passing nil as value for exposure' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'greeting'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'greeting'
+      config.default_format = :html
 
       expose :greeting, default: 'Hello Dry-rb'
     end.new
@@ -162,12 +150,10 @@ RSpec.describe 'exposures' do
 
   it 'allows exposures to depend on each other' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users_with_count'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users_with_count'
+      config.default_format = :html
 
       expose :users
 
@@ -196,12 +182,10 @@ RSpec.describe 'exposures' do
     end
 
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users_with_count'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users_with_count'
+      config.default_format = :html
 
       expose :users, as: Test::UserPart
 
@@ -232,12 +216,10 @@ RSpec.describe 'exposures' do
 
   it 'allows exposures to depend on each other while still using keywords args to access input data' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'greeting'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'greeting'
+      config.default_format = :html
 
       expose :greeting do |prefix, greeting:|
         "#{prefix} #{greeting}"
@@ -257,12 +239,10 @@ RSpec.describe 'exposures' do
 
   it 'supports default values for keyword arguments' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'greeting'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'greeting'
+      config.default_format = :html
 
       expose :greeting do |prefix, greeting: 'From the defaults'|
         "#{prefix} #{greeting}"
@@ -280,12 +260,10 @@ RSpec.describe 'exposures' do
 
   it 'only passes keywords arguments that are needed in the block and allows for default values' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'edit'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'edit'
+      config.default_format = :html
 
       expose :pretty_id do |id:|
         "Beautiful #{id}"
@@ -303,12 +281,10 @@ RSpec.describe 'exposures' do
 
   it 'supports defining multiple exposures at once' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users_with_count'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users_with_count'
+      config.default_format = :html
 
       expose :users, :users_count
 
@@ -331,12 +307,10 @@ RSpec.describe 'exposures' do
 
   it 'allows exposures to be hidden from the view' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users_with_count'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users_with_count'
+      config.default_format = :html
 
       private_expose :prefix do
         "COUNT: "
@@ -366,12 +340,10 @@ RSpec.describe 'exposures' do
 
   it 'inherit exposures from parent class' do
     parent = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users_with_count_inherit'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users_with_count_inherit'
+      config.default_format = :html
 
       private_expose :prefix do
         "COUNT: "
@@ -407,12 +379,10 @@ RSpec.describe 'exposures' do
 
   it 'inherit exposures from parent class and allow to override them' do
     parent = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users_with_count_inherit'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users_with_count_inherit'
+      config.default_format = :html
 
       private_expose :prefix do
         "COUNT: "
@@ -452,12 +422,10 @@ RSpec.describe 'exposures' do
 
   it 'makes exposures available to layout' do
     vc = Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app_with_users'
-        config.template = 'users'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app_with_users'
+      config.template = 'users'
+      config.default_format = :html
 
       expose :users_count, layout: true
 

--- a/spec/integration/part_builder_spec.rb
+++ b/spec/integration/part_builder_spec.rb
@@ -20,12 +20,10 @@ RSpec.describe 'part builder' do
   describe 'default decorator' do
     it 'looks up classes from a part namespace' do
       vc = Class.new(Dry::View::Controller) do
-        configure do |config|
-          config.paths = SPEC_ROOT.join('fixtures/templates')
-          config.layout = nil
-          config.template = 'decorated_parts'
-          config.part_namespace = Test
-        end
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = nil
+        config.template = 'decorated_parts'
+        config.part_namespace = Test
 
         expose :customs
         expose :custom
@@ -39,11 +37,9 @@ RSpec.describe 'part builder' do
 
     it 'supports wrapping array memebers in custom part classes provided to exposure :as option' do
       vc = Class.new(Dry::View::Controller) do
-        configure do |config|
-          config.paths = SPEC_ROOT.join('fixtures/templates')
-          config.layout = nil
-          config.template = 'decorated_parts'
-        end
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = nil
+        config.template = 'decorated_parts'
 
         expose :customs, as: Test::CustomPart
         expose :custom, as: Test::CustomPart
@@ -57,11 +53,9 @@ RSpec.describe 'part builder' do
 
     it 'supports wrapping an array and its members in custom part classes provided to exposure :as option as a hash' do
       vc = Class.new(Dry::View::Controller) do
-        configure do |config|
-          config.paths = SPEC_ROOT.join('fixtures/templates')
-          config.layout = nil
-          config.template = 'decorated_parts'
-        end
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = nil
+        config.template = 'decorated_parts'
 
         expose :customs, as: [Test::CustomArrayPart, Test::CustomPart]
         expose :custom, as: Test::CustomPart
@@ -83,12 +77,10 @@ RSpec.describe 'part builder' do
       end
 
       vc = Class.new(Dry::View::Controller) do
-        configure do |config|
-          config.part_builder = part_builder
-          config.paths = SPEC_ROOT.join('fixtures/templates')
-          config.layout = nil
-          config.template = 'decorated_parts'
-        end
+        config.part_builder = part_builder
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.layout = nil
+        config.template = 'decorated_parts'
 
         expose :customs, :custom, :ordinary
       end.new

--- a/spec/integration/scope_spec.rb
+++ b/spec/integration/scope_spec.rb
@@ -4,9 +4,7 @@ require "dry/view/scope"
 RSpec.describe "Scopes" do
   let(:base_vc) {
     Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = FIXTURES_PATH.join("integration/scopes")
-      end
+      config.paths = FIXTURES_PATH.join("integration/scopes")
     end
   }
 
@@ -20,10 +18,8 @@ RSpec.describe "Scopes" do
     end
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.template = "custom_view_controller_scope"
-        config.scope = Test::ControllerScope
-      end
+      config.template = "custom_view_controller_scope"
+      config.scope = Test::ControllerScope
 
       expose :text
     end.new
@@ -33,9 +29,7 @@ RSpec.describe "Scopes" do
 
   specify "Rendering a partial via an anonymous scope" do
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.template = "anonymous_scope"
-      end
+      config.template = "anonymous_scope"
 
       expose :text
     end.new
@@ -53,10 +47,8 @@ RSpec.describe "Scopes" do
     end
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.scope_namespace = Test::Scopes
-        config.template = "named_scope_with_implicit_render"
-      end
+      config.scope_namespace = Test::Scopes
+      config.template = "named_scope_with_implicit_render"
 
       expose :text
     end.new
@@ -74,10 +66,8 @@ RSpec.describe "Scopes" do
     end
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.scope_namespace = Test::Scopes
-        config.template = "class_named_scope_with_implicit_render"
-      end
+      config.scope_namespace = Test::Scopes
+      config.template = "class_named_scope_with_implicit_render"
 
       expose :text
     end.new
@@ -87,9 +77,7 @@ RSpec.describe "Scopes" do
 
   specify "Raising an error when an unnamed partial cannot be rendered implicitly" do
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.template = "unnamed_named_scope_with_implicit_render"
-      end
+      config.template = "unnamed_named_scope_with_implicit_render"
     end.new
 
     expect { vc.().to_s }.to raise_error ArgumentError, "+partial_name+ must be provided for unnamed scopes"
@@ -105,10 +93,8 @@ RSpec.describe "Scopes" do
     end
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.scope_namespace = Test::Scopes
-        config.template = "named_scope_with_explicit_render"
-      end
+      config.scope_namespace = Test::Scopes
+      config.template = "named_scope_with_explicit_render"
 
       expose :text
     end.new
@@ -126,10 +112,8 @@ RSpec.describe "Scopes" do
     end
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.scope_namespace = Test::Scopes
-        config.template = "named_scope_with_defaults"
-      end
+      config.scope_namespace = Test::Scopes
+      config.template = "named_scope_with_defaults"
 
       expose :text
     end.new
@@ -155,11 +139,9 @@ RSpec.describe "Scopes" do
     end
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.part_namespace = Test::Parts
-        config.scope_namespace = Test::Scopes
-        config.template = "scope_from_part"
-      end
+      config.part_namespace = Test::Parts
+      config.scope_namespace = Test::Scopes
+      config.template = "scope_from_part"
 
       expose :message
     end.new

--- a/spec/integration/template_engines/erbse_spec.rb
+++ b/spec/integration/template_engines/erbse_spec.rb
@@ -4,18 +4,14 @@ require "dry/view/controller"
 RSpec.describe "Template engines / erb (using erbse as default engine)" do
   let(:base_vc) {
     Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = FIXTURES_PATH.join("integration/template_engines/erbse")
-      end
+      config.paths = FIXTURES_PATH.join("integration/template_engines/erbse")
     end
   }
 
   context "with erbse available" do
     it "supports partials that yield" do
       vc = Class.new(base_vc) do
-        configure do |config|
-          config.template = "render_and_yield"
-        end
+        config.template = "render_and_yield"
       end.new
 
       expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>  Yielded</wrapper>"
@@ -29,10 +25,8 @@ RSpec.describe "Template engines / erb (using erbse as default engine)" do
       end.new
 
       vc = Class.new(base_vc) do
-        configure do |config|
-          config.default_context = context
-          config.template = "method_with_yield"
-        end
+        config.default_context = context
+        config.template = "method_with_yield"
       end.new
 
       expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>  Yielded</wrapper>"
@@ -59,9 +53,7 @@ RSpec.describe "Template engines / erb (using erbse as default engine)" do
 
     it "raises an error explaining the erbse requirement" do
       vc = Class.new(base_vc) do
-        configure do |config|
-          config.template = "render_and_yield"
-        end
+        config.template = "render_and_yield"
       end.new
 
       expect { vc.() }.to raise_error(LoadError, %r{dry-view requires erbse}m)
@@ -69,9 +61,7 @@ RSpec.describe "Template engines / erb (using erbse as default engine)" do
 
     it "allows deregistering the adapter to avoid the load error and accept rendering via a less-compatible erb engine" do
       vc = Class.new(base_vc) do
-        configure do |config|
-          config.template = "plain_erb"
-        end
+        config.template = "plain_erb"
       end.new
 
       Dry::View::Tilt.deregister_adapter :erb

--- a/spec/integration/template_engines/erubi_spec.rb
+++ b/spec/integration/template_engines/erubi_spec.rb
@@ -8,19 +8,15 @@ require "dry/view/controller"
 RSpec.describe "Template engines / erb (using erubi via an explict engine mapping)" do
   let(:base_vc) {
     Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = FIXTURES_PATH.join("integration/template_engines/erubi")
-        config.renderer_engine_mapping = {erb: Tilt::ErubiTemplate}
-        config.renderer_options = {engine_class: Erubi::CaptureEndEngine}
-      end
+      config.paths = FIXTURES_PATH.join("integration/template_engines/erubi")
+      config.renderer_engine_mapping = {erb: Tilt::ErubiTemplate}
+      config.renderer_options = {engine_class: Erubi::CaptureEndEngine}
     end
   }
 
   it "supports partials that yield" do
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.template = "render_and_yield"
-      end
+      config.template = "render_and_yield"
     end.new
 
     expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
@@ -34,10 +30,8 @@ RSpec.describe "Template engines / erb (using erubi via an explict engine mappin
     end.new
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.default_context = context
-        config.template = "method_with_yield"
-      end
+      config.default_context = context
+      config.template = "method_with_yield"
     end.new
 
     expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"

--- a/spec/integration/template_engines/hamlit_spec.rb
+++ b/spec/integration/template_engines/hamlit_spec.rb
@@ -4,18 +4,14 @@ require "dry/view/controller"
 RSpec.describe "Template engines / haml (using hamlit-block as default engine)" do
   let(:base_vc) {
     Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = FIXTURES_PATH.join("integration/template_engines/hamlit")
-      end
+      config.paths = FIXTURES_PATH.join("integration/template_engines/hamlit")
     end
   }
 
   context "with hamlit-block available" do
     it "supports partials that yield" do
       vc = Class.new(base_vc) do
-        configure do |config|
-          config.template = "render_and_yield"
-        end
+        config.template = "render_and_yield"
       end.new
 
       expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
@@ -29,10 +25,8 @@ RSpec.describe "Template engines / haml (using hamlit-block as default engine)" 
       end.new
 
       vc = Class.new(base_vc) do
-        configure do |config|
-          config.default_context = context
-          config.template = "method_with_yield"
-        end
+        config.default_context = context
+        config.template = "method_with_yield"
       end.new
 
       expect(vc.().to_s.gsub(/\n\s*/m, "")).to eq "<wrapper>Yielded</wrapper>"
@@ -58,9 +52,7 @@ RSpec.describe "Template engines / haml (using hamlit-block as default engine)" 
 
     it "raises an error explaining the hamlit-block requirement" do
       vc = Class.new(base_vc) do
-        configure do |config|
-          config.template = "render_and_yield"
-        end
+        config.template = "render_and_yield"
       end.new
 
       expect { vc.() }.to raise_error(LoadError, %r{dry-view requires hamlit-block}m)

--- a/spec/integration/template_engines/slim_spec.rb
+++ b/spec/integration/template_engines/slim_spec.rb
@@ -5,17 +5,13 @@ require "dry/view/controller"
 RSpec.describe "Template engines / slim" do
   let(:base_vc) {
     Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = FIXTURES_PATH.join("integration/template_engines/slim")
-      end
+      config.paths = FIXTURES_PATH.join("integration/template_engines/slim")
     end
   }
 
   it "supports partials that yield" do
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.template = "render_and_yield"
-      end
+      config.template = "render_and_yield"
     end.new
 
     expect(vc.().to_s).to eq "<wrapper>Yielded</wrapper>"
@@ -29,10 +25,8 @@ RSpec.describe "Template engines / slim" do
     end.new
 
     vc = Class.new(base_vc) do
-      configure do |config|
-        config.default_context = context
-        config.template = "method_with_yield"
-      end
+      config.default_context = context
+      config.template = "method_with_yield"
     end.new
 
     expect(vc.().to_s).to eq "<wrapper>Yielded</wrapper>"

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -2,12 +2,10 @@
 RSpec.describe 'dry-view' do
   let(:vc_class) do
     Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'users'
-        config.default_format = :html
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'users'
+      config.default_format = :html
 
       expose :users do
         [
@@ -40,9 +38,7 @@ RSpec.describe 'dry-view' do
 
   it 'renders without a layout' do
     vc = Class.new(vc_class) do
-      configure do |config|
-        config.layout = false
-      end
+      config.layout = false
     end.new
 
     expect(vc.(context: context).to_s).to eql(
@@ -61,9 +57,7 @@ RSpec.describe 'dry-view' do
 
   it 'renders a view with a template on another view path' do
     vc = Class.new(vc_class) do
-      configure do |config|
-        config.paths = [SPEC_ROOT.join('fixtures/templates_override')] + Array(config.paths)
-      end
+      config.paths = [SPEC_ROOT.join('fixtures/templates_override')] + Array(config.paths)
     end.new
 
     expect(vc.(context: context).to_s).to eq(
@@ -73,9 +67,7 @@ RSpec.describe 'dry-view' do
 
   it 'renders a view that passes arguments to partials' do
     vc = Class.new(vc_class) do
-      configure do |config|
-        config.template = 'parts_with_args'
-      end
+      config.template = 'parts_with_args'
     end.new
 
     expect(vc.(context: context).to_s).to eq(
@@ -85,9 +77,7 @@ RSpec.describe 'dry-view' do
 
   it 'renders using utf-8 by default' do
     vc = Class.new(vc_class) do
-      configure do |config|
-        config.template = 'utf8'
-      end
+      config.template = 'utf8'
     end.new
 
     expect(vc.(context: context).to_s).to eq(
@@ -108,17 +98,13 @@ RSpec.describe 'dry-view' do
 
     let(:child_view) do
       Class.new(parent_view) do
-        configure do |config|
-          config.template = 'tasks'
-        end
+        config.template = 'tasks'
       end
     end
 
     it 'renders within a parent class layout using provided context' do
       vc = Class.new(vc_class) do
-        configure do |config|
-          config.template = 'tasks'
-        end
+        config.template = 'tasks'
 
         expose :tasks do
           [

--- a/spec/unit/controller_spec.rb
+++ b/spec/unit/controller_spec.rb
@@ -3,11 +3,9 @@ require "tilt/erubi"
 RSpec.describe Dry::View::Controller do
   subject(:controller) {
     Class.new(Dry::View::Controller) do
-      configure do |config|
-        config.paths = SPEC_ROOT.join('fixtures/templates')
-        config.layout = 'app'
-        config.template = 'user'
-      end
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.layout = 'app'
+      config.template = 'user'
 
       expose :user do
         {name: 'Jane'}
@@ -36,9 +34,7 @@ RSpec.describe Dry::View::Controller do
 
     it 'provides a meaningful error if the template name is missing' do
       controller = Class.new(Dry::View::Controller) do
-        configure do |config|
-          config.paths = SPEC_ROOT.join('fixtures/templates')
-        end
+        config.paths = SPEC_ROOT.join('fixtures/templates')
       end.new
 
       expect { controller.(context: context) }.to raise_error Dry::View::Controller::UndefinedTemplateError
@@ -48,12 +44,10 @@ RSpec.describe Dry::View::Controller do
   describe 'renderer options' do
     subject(:controller) {
       Class.new(Dry::View::Controller) do
-        configure do |config|
-          config.paths = SPEC_ROOT.join('fixtures/templates')
-          config.template = 'controller_renderer_options'
-          config.renderer_engine_mapping = {erb: Tilt::ErubiTemplate}
-          config.renderer_options = {outvar: '@__buf__'}
-        end
+        config.paths = SPEC_ROOT.join('fixtures/templates')
+        config.template = 'controller_renderer_options'
+        config.renderer_engine_mapping = {erb: Tilt::ErubiTemplate}
+        config.renderer_options = {outvar: '@__buf__'}
       end.new
     }
 


### PR DESCRIPTION
This:

- Reduces boilerplate in view controller classes,
- Makes it clearer how 3rd parties (e.g. hanami) can more easily apply their own default configuration values in view controller classes that they vend

Resolves #81