### PR TITLE
Extract decorated attributes behavior into a single, shared module

### DIFF
--- a/lib/dry/view/context.rb
+++ b/lib/dry/view/context.rb
@@ -1,27 +1,11 @@
 require "dry/equalizer"
-require "set"
+require_relative "decorated_attributes"
 
 module Dry
   module View
     class Context
-      DECORATED_ATTRIBUTES = :DecoratedAttributes
-
-      def self.decorate(*names, **options)
-        decorated_attributes.decorate(*names, **options)
-      end
-
-      def self.decorated_attributes
-        if const_defined?(DECORATED_ATTRIBUTES, false)
-          const_get(DECORATED_ATTRIBUTES)
-        else
-          const_set(DECORATED_ATTRIBUTES, DecoratedAttributes.new).tap do |mod|
-            prepend mod
-          end
-        end
-      end
-      private_class_method :decorated_attributes
-
       include Dry::Equalizer(:_options)
+      include DecoratedAttributes
 
       attr_reader :_rendering, :_options
 
@@ -36,41 +20,8 @@ module Dry
         self.class.new(**_options.merge(rendering: rendering))
       end
 
-      def rendering?
-        !!_rendering
-      end
-
       def with(**new_options)
         self.class.new(rendering: _rendering, **_options.merge(new_options))
-      end
-
-      class DecoratedAttributes < Module
-        def initialize(*)
-          @names = Set.new
-          super
-        end
-
-        def decorate(*names, **options)
-          @names += names
-
-          class_eval do
-            names.each do |name|
-              define_method name do
-                attribute = super()
-
-                if rendering? && attribute
-                  _rendering.part(name, attribute, **options)
-                else
-                  attribute
-                end
-              end
-            end
-          end
-        end
-
-        def inspect
-          %(#<#{self.class.name}#{@names.to_a.sort.inspect}>)
-        end
       end
     end
   end

--- a/lib/dry/view/decorated_attributes.rb
+++ b/lib/dry/view/decorated_attributes.rb
@@ -1,0 +1,60 @@
+require "set"
+
+module Dry
+  module View
+    module DecoratedAttributes
+      def self.included(klass)
+        klass.extend ClassInterface
+      end
+
+      module ClassInterface
+        MODULE_NAME = :DecoratedAttributes
+
+        def decorate(*names, **options)
+          decorated_attributes.decorate(*names, **options)
+        end
+
+        private
+
+        def decorated_attributes
+          if const_defined?(MODULE_NAME, false)
+            const_get(MODULE_NAME)
+          else
+            const_set(MODULE_NAME, Attributes.new).tap do |mod|
+              prepend mod
+            end
+          end
+        end
+      end
+
+      class Attributes < Module
+        def initialize(*)
+          @names = Set.new
+          super
+        end
+
+        def decorate(*names, **options)
+          @names += names
+
+          class_eval do
+            names.each do |name|
+              define_method name do
+                attribute = super()
+
+                if _rendering && attribute
+                  _rendering.part(name, attribute, **options)
+                else
+                  attribute
+                end
+              end
+            end
+          end
+        end
+
+        def inspect
+          %(#<#{self.class.name}#{@names.to_a.sort.inspect}>)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/context_spec.rb
+++ b/spec/unit/context_spec.rb
@@ -35,15 +35,9 @@ RSpec.describe Dry::View::Context do
 
   subject(:context) { context_class.new(assets: assets, routes: routes) }
 
-  it { is_expected.not_to be_rendering }
-
   describe "attribute readers" do
     it "provides access to its attributes" do
       expect(context.assets).to eql assets
-    end
-
-    it "raises NoMethodError when an invalid attribute is accessed" do
-      expect { context.invalid_attribute }.to raise_error(NoMethodError)
     end
   end
 
@@ -52,20 +46,10 @@ RSpec.describe Dry::View::Context do
       context_class.new(assets: assets, routes: routes).for_rendering(rendering)
     }
 
-    it { is_expected.to be_rendering }
-
     describe "attribute readers" do
       it "provides attributes decorated in view parts" do
         expect(context.assets).to be_a Dry::View::Part
         expect(context.assets.value).to eql assets
-      end
-
-      it "raises NoMethodError when an invalid attribute is decorated" do
-        expect { context.invalid_attribute }.to raise_error(NoMethodError)
-      end
-
-      it "stores the decorated attribute readers in a single decorated attributes module" do
-        expect(context_class.ancestors[0].inspect).to eq "#<Dry::View::Context::DecoratedAttributes[:assets, :invalid_attribute, :routes]>"
       end
     end
   end

--- a/spec/unit/decorated_attributes_spec.rb
+++ b/spec/unit/decorated_attributes_spec.rb
@@ -1,0 +1,50 @@
+require "dry/view/decorated_attributes"
+
+RSpec.describe Dry::View::DecoratedAttributes do
+  subject(:decoratable) {
+    Test::Decoratable = Struct.new(:attr_1, :attr_2, :_rendering) do
+      include Dry::View::DecoratedAttributes
+
+      decorate :attr_1, as: :my_value
+      decorate :attr_2
+      decorate :invalid_attr
+    end
+
+    Test::Decoratable.new(attr_1, attr_2, rendering)
+  }
+
+  let(:attr_1) { double(:attr_1) }
+  let(:attr_2) { double(:attr_2) }
+  let(:rendering) { spy(:rendering) }
+
+  context "with rendering" do
+    it "returns decorated attributes as parts" do
+      decoratable.attr_1
+      expect(rendering).to have_received(:part).with(:attr_1, attr_1, as: :my_value)
+
+      decoratable.attr_2
+      expect(rendering).to have_received(:part).with(:attr_2, attr_2, {})
+    end
+
+    it "raises NoMethodError when an invalid attribute is accessed" do
+      expect { decoratable.invalid_attr }.to raise_error(NoMethodError)
+    end
+  end
+
+  context "without rendering" do
+    let(:rendering) { nil }
+
+    it "returns attributes without decoration" do
+      expect(decoratable.attr_1).to be attr_1
+    end
+
+    it "raises NoMethodError when an invalid attribute is accessed" do
+      expect { decoratable.invalid_attr }.to raise_error(NoMethodError)
+    end
+  end
+
+  it "prepends a single module to provide the decorated attribute readers" do
+    expect(decoratable.class.ancestors.map(&:name).grep(/Test::Decoratable::DecoratedAttributes/).length).to eq 1
+    expect(decoratable.class.ancestors[0].inspect).to eq "#<Dry::View::DecoratedAttributes::Attributes[:attr_1, :attr_2, :invalid_attr]>"
+  end
+end


### PR DESCRIPTION
Now attribute decoration on Context and Part behave identically, which means that it's now possible to decorate methods defined directly on Part classes, which wasn't possible with the previous behavior there (which relied on method_missing).

Resolves #99