### PR TITLE
Allow Scope objects to be initialized without a rendering

### DIFF
--- a/lib/dry/view/rendering_missing.rb
+++ b/lib/dry/view/rendering_missing.rb
@@ -13,6 +13,10 @@ module Dry
         raise MissingRenderingError
       end
 
+      def context
+        raise MissingRenderingError
+      end
+
       def part(name, value, **options)
         raise MissingRenderingError
       end

--- a/lib/dry/view/scope.rb
+++ b/lib/dry/view/scope.rb
@@ -1,5 +1,6 @@
 require 'dry/equalizer'
 require 'dry/core/constants'
+require_relative "rendering_missing"
 
 module Dry
   class View
@@ -12,7 +13,7 @@ module Dry
       attr_reader :_locals
       attr_reader :_rendering
 
-      def initialize(name: nil, locals: Dry::Core::Constants::EMPTY_HASH, rendering:)
+      def initialize(name: nil, locals: Dry::Core::Constants::EMPTY_HASH, rendering: RenderingMissing.new)
         @_name = name
         @_locals = locals
         @_rendering = rendering

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -1,79 +1,106 @@
 require 'dry/view/scope_builder'
 
 RSpec.describe Dry::View::Scope do
-  subject(:scope) {
-    described_class.new(
-      locals: locals,
-      rendering: rendering,
-    )
-  }
-
   let(:locals) { {} }
-  let(:rendering) { spy(:rendering, context: context) }
-  let(:context) { double(:context) }
 
-  describe '#render' do
-    it 'renders a partial with itself as the scope' do
-      scope.render(:info)
-      expect(rendering).to have_received(:partial).with(:info, scope)
-    end
-
-    it 'renders a partial with provided locals' do
-      scope_with_locals = described_class.new(
-        locals: {foo: 'bar'},
+  context "with a rendering provided" do
+    subject(:scope) {
+      described_class.new(
+        locals: locals,
         rendering: rendering,
       )
+    }
 
-      scope.render(:info, foo: 'bar')
+    let(:rendering) { spy(:rendering, context: context) }
+    let(:context) { double(:context) }
 
-      expect(rendering).to have_received(:partial).with(:info, scope_with_locals)
+    describe '#render' do
+      it 'renders a partial with itself as the scope' do
+        scope.render(:info)
+        expect(rendering).to have_received(:partial).with(:info, scope)
+      end
+
+      it 'renders a partial with provided locals' do
+        scope_with_locals = described_class.new(
+          locals: {foo: 'bar'},
+          rendering: rendering,
+        )
+
+        scope.render(:info, foo: 'bar')
+
+        expect(rendering).to have_received(:partial).with(:info, scope_with_locals)
+      end
+    end
+
+    describe "#_context" do
+      it "returns the rendering's context" do
+        expect(scope._context).to be context
+      end
+    end
+
+    describe '#method_missing' do
+      describe 'matching locals' do
+        let(:locals) { {greeting: 'hello from locals'} }
+        let(:context) { double(:context, greeting: 'hello from context') }
+
+        it 'returns a matching value from the locals, in favour of a matching method on the context' do
+          expect(scope.greeting).to eq 'hello from locals'
+        end
+      end
+
+      describe 'matching context' do
+        let(:context) { double(:context, greeting: 'hello from context') }
+
+        it 'calls the matching method on the context' do
+          expect(scope.greeting).to eq 'hello from context'
+        end
+
+        it 'forwards all arguments to the method' do
+          blk = -> { }
+          scope.greeting 'args', &blk
+
+          expect(context).to have_received(:greeting).with('args', &blk)
+        end
+      end
+
+      describe 'matching convenience methods' do
+        it 'provides #context' do
+          expect(scope.context).to be context
+        end
+
+        it 'provides #locals' do
+          expect(scope.locals).to be locals
+        end
+      end
+
+      describe 'no matches' do
+        it 'raises an error' do
+          expect { scope.greeting }.to raise_error(NoMethodError)
+        end
+      end
     end
   end
 
-  describe "#_context" do
-    it "returns the rendering's context" do
-      expect(scope._context).to be context
-    end
-  end
+  context "without a rendering provided" do
+    subject(:scope) {
+      described_class.new(locals: locals)
+    }
 
-  describe '#method_missing' do
-    describe 'matching locals' do
-      let(:locals) { {greeting: 'hello from locals'} }
-      let(:context) { double(:context, greeting: 'hello from context') }
-
-      it 'returns a matching value from the locals, in favour of a matching method on the context' do
-        expect(scope.greeting).to eq 'hello from locals'
+    describe "#render" do
+      it "raises an error" do
+        expect { scope.render(:info) }.to raise_error(Dry::View::RenderingMissing::MissingRenderingError)
       end
     end
 
-    describe 'matching context' do
-      let(:context) { double(:context, greeting: 'hello from context') }
-
-      it 'calls the matching method on the context' do
-        expect(scope.greeting).to eq 'hello from context'
-      end
-
-      it 'forwards all arguments to the method' do
-        blk = -> { }
-        scope.greeting 'args', &blk
-
-        expect(context).to have_received(:greeting).with('args', &blk)
+    describe "#scope" do
+      it "raises an error" do
+        expect { scope.scope(:info) }.to raise_error(Dry::View::RenderingMissing::MissingRenderingError)
       end
     end
 
-    describe 'matching convenience methods' do
-      it 'provides #context' do
-        expect(scope.context).to be context
-      end
-
-      it 'provides #locals' do
-        expect(scope.locals).to be locals
-      end
-    end
-
-    describe 'no matches' do
-      it 'raises an error' do
-        expect { scope.greeting }.to raise_error(NoMethodError)
+    describe "#_context" do
+      it "raises an error" do
+        expect { scope._context }.to raise_error(Dry::View::RenderingMissing::MissingRenderingError)
       end
     end
   end


### PR DESCRIPTION
In this case a RenderingMissing is used. This may be useful for unit testing the aspects of a scope that don't rely on any rendering details.