### PR TITLE
Give access to current rendering format from Part and Scope

### DIFF
--- a/lib/dry/view/part.rb
+++ b/lib/dry/view/part.rb
@@ -6,6 +6,7 @@ module Dry
   class View
     class Part
       CONVENIENCE_METHODS = %i[
+        format
         context
         render
         scope
@@ -29,6 +30,14 @@ module Dry
         @_name = name
         @_value = value
         @_rendering = rendering
+      end
+
+      def _format
+        _rendering.format
+      end
+
+      def _context
+        _rendering.context
       end
 
       def _render(partial_name, as: _name, **locals, &block)
@@ -57,10 +66,6 @@ module Dry
       end
 
       private
-
-      def _context
-        _rendering.context
-      end
 
       def method_missing(name, *args, &block)
         if _value.respond_to?(name)

--- a/lib/dry/view/rendering.rb
+++ b/lib/dry/view/rendering.rb
@@ -25,6 +25,10 @@ module Dry
         @part_builder = part_builder.for_rendering(self)
       end
 
+      def format
+        renderer.format
+      end
+
       def part(name, value, **options)
         part_builder.(name, value, **options)
       end

--- a/lib/dry/view/scope.rb
+++ b/lib/dry/view/scope.rb
@@ -5,7 +5,7 @@ require_relative "rendering_missing"
 module Dry
   class View
     class Scope
-      CONVENIENCE_METHODS = %i[context locals].freeze
+      CONVENIENCE_METHODS = %i[format context locals].freeze
 
       include Dry::Equalizer(:_name, :_locals, :_rendering)
 
@@ -29,6 +29,10 @@ module Dry
 
       def scope(name = nil, **locals)
         _rendering.scope(name, locals)
+      end
+
+      def _format
+        _rendering.format
       end
 
       def _context

--- a/spec/unit/part_spec.rb
+++ b/spec/unit/part_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Dry::View::Part do
       part_builder: Dry::View::ScopeBuilder.new,
     )
   }
-  let(:renderer) { spy(:renderer) }
+  let(:renderer) { spy(:renderer, format: :xml) }
 
   context 'with a rendering provided' do
     subject(:part) {
@@ -60,13 +60,19 @@ RSpec.describe Dry::View::Part do
     describe '#new' do
       it 'preserves rendering' do
         new_part = part.new(value: 'new value')
-        expect(new_part._rendering).to eql part._rendering
+        expect(new_part._rendering).to be part._rendering
       end
     end
 
     describe "#inspect" do
       it "includes the clsas name, name, and value only" do
         expect(part.inspect).to eq "#<Dry::View::Part name=:user value=#<Double :value>>"
+      end
+    end
+
+    describe "#_format" do
+      it "returns the rendering's format" do
+        expect(part._format).to eq :xml
       end
     end
 
@@ -84,17 +90,19 @@ RSpec.describe Dry::View::Part do
         expect(value).to have_received(:greeting).with('args', &blk)
       end
 
-      it 'raises an error if no metho matches' do
+      it 'raises an error if no method matches' do
         expect { part.farewell }.to raise_error(NoMethodError)
       end
     end
 
-    describe '#respond_to' do
+    describe '#respond_to?' do
       let(:value) { double(greeting: 'hello from value') }
 
       it 'handles convenience methods' do
+        expect(part).to respond_to(:format)
         expect(part).to respond_to(:context)
         expect(part).to respond_to(:render)
+        expect(part).to respond_to(:scope)
         expect(part).to respond_to(:value)
       end
 
@@ -111,6 +119,12 @@ RSpec.describe Dry::View::Part do
         value: value,
       )
     }
+
+    describe "#format" do
+      it "raises an error" do
+        expect { part.render(:info) }.to raise_error(Dry::View::RenderingMissing::MissingRenderingError)
+      end
+    end
 
     describe '#render' do
       it 'raises an error' do

--- a/spec/unit/rendering_spec.rb
+++ b/spec/unit/rendering_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe Dry::View::Rendering do
     }
   }
 
+  describe "#format" do
+    it "returns the renderer's format" do
+      expect(rendering.format).to eq :html
+    end
+  end
+
   describe "#==" do
     it "is equal when its options are equal" do
       expect(rendering).to eq described_class.new(**rendering_options)

--- a/spec/unit/scope_spec.rb
+++ b/spec/unit/scope_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Dry::View::Scope do
       )
     }
 
-    let(:rendering) { spy(:rendering, context: context) }
+    let(:rendering) { spy(:rendering, format: :xml, context: context) }
     let(:context) { double(:context) }
 
     describe '#render' do
@@ -29,6 +29,12 @@ RSpec.describe Dry::View::Scope do
         scope.render(:info, foo: 'bar')
 
         expect(rendering).to have_received(:partial).with(:info, scope_with_locals)
+      end
+    end
+
+    describe "#_format" do
+      it "returns the rendering's format" do
+        expect(scope._format).to eq :xml
       end
     end
 


### PR DESCRIPTION
Having access to the current format is useful in certain circumstances.

For example, from a Part which uses i18n to return translations that may need to differ per-format (e.g. translations for the HTML format may need embedded markup)

Resolves #111 