### PR TITLE
Make context object available to exposures via matching keyword param

### DIFF
--- a/lib/dry/view.rb
+++ b/lib/dry/view.rb
@@ -133,7 +133,7 @@ module Dry
     private
 
     def locals(rendering, input)
-      exposures.(input) do |value, exposure|
+      exposures.(context: rendering.context, **input) do |value, exposure|
         if exposure.decorate? && value
           rendering.part(exposure.name, value, **exposure.options)
         else

--- a/spec/integration/view/exposures_spec.rb
+++ b/spec/integration/view/exposures_spec.rb
@@ -1,0 +1,25 @@
+require "dry/view"
+require "dry/view/context"
+
+RSpec.describe "View / exposures" do
+  specify "exposures have access to context" do
+    view = Class.new(Dry::View) do
+      config.paths = SPEC_ROOT.join('fixtures/templates')
+      config.template = "greeting"
+
+      expose :greeting do |greeting:, context:|
+        "#{greeting}, #{context.name}"
+      end
+    end.new
+
+    context = Class.new(Dry::View::Context) do
+      def name
+        "Jane"
+      end
+    end.new
+
+    local = view.(greeting: "Hello", context: context).locals[:greeting]
+
+    expect(local.value).to eq "Hello, Jane"
+  end
+end

--- a/spec/integration/view/locals_spec.rb
+++ b/spec/integration/view/locals_spec.rb
@@ -1,7 +1,7 @@
 require "dry/view"
 require "dry/view/part"
 
-RSpec.describe "locals" do
+RSpec.describe "View / locals" do
   specify "locals are decorated with parts by default" do
     view = Class.new(Dry::View) do
       config.paths = SPEC_ROOT.join('fixtures/templates')


### PR DESCRIPTION
Since `context:` is a reserved keyword param for `View#call` anyway, and since exposure dependencies already implicitly have the context (since they're Part objects by that point), it should be no harm to make the context available for those who want to use it directly when building their exposures.

@waiting-for-dev What do you reckon? :)