### PR TITLE
Demonstrate unit testing parts; add small testing helpers

### DIFF
--- a/spec/fixtures/integration/testing/view.html.slim
+++ b/spec/fixtures/integration/testing/view.html.slim
@@ -1,0 +1,1 @@
+/ Intentionally left blank

--- a/spec/fixtures/integration/testing/view/_feature_box.html.slim
+++ b/spec/fixtures/integration/testing/view/_feature_box.html.slim
@@ -1,0 +1,2 @@
+.feature-article
+  h1 = article.title

--- a/spec/integration/testing/testing_parts_spec.rb
+++ b/spec/integration/testing/testing_parts_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe "Testing / parts" do
+  let(:part_class) {
+    Class.new(Dry::View::Part) do
+    end
+  }
+
+  specify "Parts can be unit tested without name or rendering (for testing methods that don't require them)" do
+    part_class = Class.new(Dry::View::Part) do
+      def breaking_news_title
+        title + "!"
+      end
+    end
+
+    article = Struct.new(:title).new("Giant Hand Threatens Beach City")
+
+    article_part = part_class.new(value: article)
+
+    expect(article_part.breaking_news_title).to eq "Giant Hand Threatens Beach City!"
+  end
+
+  specify "Parts can be unit tested with a rendering from a view class" do
+    view_class = Class.new(Dry::View) do
+      config.paths = FIXTURES_PATH.join("integration/testing")
+      config.template = "view"
+    end
+
+    part_class = Class.new(Dry::View::Part) do
+      def feature_box
+        render(:feature_box)
+      end
+    end
+
+    article = Struct.new(:title).new("A Guide to Beach City Funland")
+
+    article_part = part_class.new(
+      name: :article,
+      value: article,
+      rendering: view_class.template_rendering
+    )
+
+    expect(article_part.feature_box).to eq %(
+      <div class="feature-article"><h1>A Guide to Beach City Funland</h1></div>
+    ).strip
+  end
+end


### PR DESCRIPTION
Add integration spec demonstrating unit testing of parts

Add a `View.template_rendering` method so that an appropriate rendering object for a particular view can be accessed (for testing purposes)

Resolves #68 