### PR TITLE
Prevent needless partial lookup in `<template name>/shared`

### DIFF
--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -14,9 +14,11 @@ module Dry
         @root = Pathname(options.fetch(:root, dir))
       end
 
-      def lookup(name, format)
+      def lookup(name, format, include_shared: true)
         fetch_or_store(dir, root, name, format) do
-          template?(name, format) || template?("shared/#{name}", format) || !root? && chdir('..').lookup(name, format)
+          template?(name, format) ||
+            (include_shared && template?("shared/#{name}", format)) ||
+            !root? && chdir('..').lookup(name, format)
         end
       end
 

--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -9,9 +9,9 @@ module Dry
 
       attr_reader :dir, :root
 
-      def initialize(dir, options = {})
+      def initialize(dir, root: dir)
         @dir = Pathname(dir)
-        @root = Pathname(options.fetch(:root, dir))
+        @root = root
       end
 
       def lookup(name, format, include_shared: true)

--- a/lib/dry/view/renderer.rb
+++ b/lib/dry/view/renderer.rb
@@ -50,7 +50,7 @@ module Dry
 
       def lookup(name)
         paths.inject(false) { |_, path|
-          result = path.lookup(name, format)
+          result = path.lookup(name, format, include_shared: false)
           break result if result
         }
       end


### PR DESCRIPTION
It's pointless putting partials in that directory (`<path>/<template name>` is already exclusive to the current template so the extra "shared" nesting makes no sense), so stop checking it and save ourselves the filesystem hit.

Resolves #122 