### PR TITLE
CI: use jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ before_script:
 after_script:
   - "[ -d coverage ] && ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
 rvm:
-  - 2.6.0
+  - 2.6.1
   - 2.5.3
   - 2.4.5
   - 2.3.8
-  - jruby-9.2.5.0
+  - jruby-9.2.6.0
 notifications:
   email: false
   webhooks:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, 9.2.6.0.

[JRuby 9.2.6.0 release blog post](https://www.jruby.org/2019/02/11/jruby-9-2-6-0.html)