### PR TITLE
Fix typo in contexts documentation

### DIFF
--- a/docsite/source/context.html.md
+++ b/docsite/source/context.html.md
@@ -61,7 +61,7 @@ end
 The default context can be `configured` for a view:
 
 ```ruby
-class MyView < Dry::Vew
+class MyView < Dry::View
   config.default_context = MyContext.new
 end
 ```


### PR DESCRIPTION
Fixes a typo in code sample in contexts documentation.