### PR TITLE
Path should cast Pathname to String

### DIFF
--- a/lib/dry/view/path.rb
+++ b/lib/dry/view/path.rb
@@ -38,7 +38,7 @@ module Dry
       end
 
       def to_s
-        dir
+        dir.to_s
       end
 
       private

--- a/spec/unit/path_spec.rb
+++ b/spec/unit/path_spec.rb
@@ -1,0 +1,11 @@
+# frozen-string-literal: true
+
+require "dry/view/path"
+
+RSpec.describe Dry::View::Path do
+  subject(:path) { Dry::View::Path.new(SPEC_ROOT.join("fixtures/templates")) }
+
+  it "returns path as String when cast as String" do
+    expect(path.to_s).to eq SPEC_ROOT.join("fixtures/templates").to_s
+  end
+end


### PR DESCRIPTION
Delegating #to_s to a Pathname instance won't cause the value to be a
String as expected.

Call #to_s on the Pathname to ensure we get a String back.

Closes #133