### PR TITLE
Add super call to introduction example

### DIFF
--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -53,6 +53,7 @@ class ArticleView < Dry::View
 
   def initialize(article_repo:)
     @article_repo = article_repo
+    super
   end
 
   expose :article do |slug:|


### PR DESCRIPTION
A call to `super` is now needed any time you add your own constructor in a `Dry::View` class. Without it, the example given won't work:
```
6] pry(main)> 
[7] pry(main)> class ArticleView < Dry::View
[7] pry(main)*   config.paths = [File.join(__dir__, "templates")]  
[7] pry(main)*   config.part_namespace = Parts  
[7] pry(main)*   config.layout = "application"  
[7] pry(main)*   config.template = "articles/show"  
[7] pry(main)*   
[7] pry(main)*   attr_reader :article_repo  
[7] pry(main)*   
[7] pry(main)*   def initialize(article_repo:)  
[7] pry(main)*     @article_repo = article_repo    
[7] pry(main)*   end    
[7] pry(main)*   
[7] pry(main)*   expose :article do |slug:|  
[7] pry(main)*     article_repo.by_slug(slug)    
[7] pry(main)*   end    
[7] pry(main)* end  
=> #<Dry::View::Exposure name=:article proc=#<Proc:0x0000558b9de07b48 (pry):16> object=nil options={}>
[8] pry(main)> ArticleView.new(article_repo: OpenStruct.new(by_slug: 'hi'))
=> #<ArticleView config=#<Dry::Configurable::Config values={:paths=>[#<Dry::View::Path dir=#<Pathname:./templates> root=#<Pathname:./templates>>], :template=>"articles/show", :layout=>"application", :layouts_dir=>"layouts", :scope=>nil, :default_context=>#<Dry::View::Context _options={}>, :default_format=>:html, :part_namespace=>Parts, :part_builder=>Dry::View::PartBuilder, :scope_namespace=>nil, :scope_builder=>Dry::View::ScopeBuilder, :inflector=>#<Dry::Inflector>, :renderer_options=>{:default_encoding=>"utf-8"}, :renderer_engine_mapping=>nil}> exposures=nil>
[9] pry(main)> ArticleView.new(article_repo: OpenStruct.new(by_slug: 'hi')).call
NoMethodError: undefined method `call' for nil:NilClass
from /usr/local/bundle/ruby/2.7.0/gems/dry-view-0.7.1/lib/dry/view.rb:493:in `local
```