### PR TITLE
issue: fix dry-configurable warnings

### DIFF
--- a/lib/dry/view.rb
+++ b/lib/dry/view.rb
@@ -58,7 +58,7 @@ module Dry
     #
     #   @api public
     # @!scope class
-    setting :paths do |paths|
+    setting :paths, constructor: -> paths do
       Array(paths).map { |path| Path[path] }
     end
 
@@ -83,7 +83,7 @@ module Dry
     #   @param name [String, FalseClass, nil] layout name, or false to indicate no layout
     #   @api public
     # @!scope class
-    setting :layout, false
+    setting :layout, default: false
 
     # @overload config.layouts_dir=(dir)
     #   Set the name of the directory (within the configured `paths`) holding
@@ -92,7 +92,7 @@ module Dry
     #   @param dir [String] directory name
     #   @api public
     # @!scope class
-    setting :layouts_dir, "layouts"
+    setting :layouts_dir, default: "layouts"
 
     # @overload config.scope=(scope_class)
     #   Set the scope class to use when rendering the view's template.
@@ -118,7 +118,7 @@ module Dry
     #   @param context [Dry::View::Context] context object
     #   @api public
     # @!scope class
-    setting :default_context, Context.new.freeze
+    setting :default_context, default: Context.new.freeze
 
     # @overload config.default_format=(format)
     #   Set the default format to use when rendering.
@@ -128,7 +128,7 @@ module Dry
     #   @param format [Symbol]
     #   @api public
     # @!scope class
-    setting :default_format, :html
+    setting :default_format, default: :html
 
     # @overload config.scope_namespace=(namespace)
     #   Set a namespace that will be searched when building scope classes.
@@ -149,7 +149,7 @@ module Dry
     #   @param part_builder [Class]
     #   @api public
     # @!scope class
-    setting :part_builder, PartBuilder
+    setting :part_builder, default: PartBuilder
 
     # @overload config.scope_namespace=(namespace)
     #   Set a namespace that will be searched when building scope classes.
@@ -170,7 +170,7 @@ module Dry
     #   @param scope_builder [Class]
     #   @api public
     # @!scope class
-    setting :scope_builder, ScopeBuilder
+    setting :scope_builder, default: ScopeBuilder
 
     # @overload config.inflector=(inflector)
     #   Set an inflector to provide to the part_builder and scope_builder.
@@ -180,7 +180,7 @@ module Dry
     #   @param inflector
     #   @api public
     # @!scope class
-    setting :inflector, Dry::Inflector.new
+    setting :inflector, default: Dry::Inflector.new
 
     # @overload config.renderer_options=(options)
     #   A hash of options to pass to the template engine. Template engines are
@@ -195,7 +195,7 @@ module Dry
     #   @param options [Hash] renderer options
     #   @api public
     # @!scope class
-    setting :renderer_options, DEFAULT_RENDERER_OPTIONS do |options|
+    setting :renderer_options, default: DEFAULT_RENDERER_OPTIONS, constructor: -> options do
       DEFAULT_RENDERER_OPTIONS.merge(options.to_h).freeze
     end
 

--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -89,9 +89,9 @@ RSpec.describe "dry-view" do
     let(:parent_view) do
       klass = Class.new(Dry::View)
 
-      klass.setting :paths, SPEC_ROOT.join("fixtures/templates")
-      klass.setting :layout, "app"
-      klass.setting :formats, html: :slim
+      klass.setting :paths, default: SPEC_ROOT.join("fixtures/templates")
+      klass.setting :layout, default: "app"
+      klass.setting :formats, default: { html: :slim }
 
       klass
     end


### PR DESCRIPTION
This PR addresses https://github.com/dry-rb/dry-view/issues/151
by using `default` and `constructor` keyword args during settings instantiation.