### PR TITLE
rubocop: fix build

### DIFF
--- a/spec/integration/view_spec.rb
+++ b/spec/integration/view_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "dry-view" do
 
       klass.setting :paths, default: SPEC_ROOT.join("fixtures/templates")
       klass.setting :layout, default: "app"
-      klass.setting :formats, default: { html: :slim }
+      klass.setting :formats, default: {html: :slim}
 
       klass
     end


### PR DESCRIPTION
This PR fixes Rubocop issues introduced in https://github.com/dry-rb/dry-view/pull/153 

In order to get a green build I had to add `hamlit` & `hamlit-block` version requirements as tests were failing for `hamlit` older than `2.16.0` and  `hamlit-block` older than `0.7.1`