### PR TITLE
Add Config subclass with immutable Equalizer

### DIFF
--- a/lib/dry/view.rb
+++ b/lib/dry/view.rb
@@ -34,6 +34,10 @@ module Dry
   #
   # @api public
   class View
+    class Config < Dry::Configurable::Config
+      include Dry::Equalizer(:values, immutable: true)
+    end
+
     # @api private
     DEFAULT_RENDERER_OPTIONS = {default_encoding: "utf-8"}.freeze
 
@@ -41,7 +45,7 @@ module Dry
 
     extend Dry::Core::Cache
 
-    extend Dry::Configurable
+    extend Dry::Configurable(config_class: Dry::View::Config)
 
     # @!group Configuration
 


### PR DESCRIPTION
When extending Dry::Configurable, the default is to initialize a Dry::Equalizer without immutability on the hash method.

When Dry::View fetches or stores a template, Dry::Core::Cache uses a hash of the arguments. Since this hashing will occur for every nested template, it can be quite computationally demanding. In the case of fetching or storing templates, the values being hashed shouldn't change and so the result can be memoized.

In my benchmarks, I'm using a highly contrived template that loads 100 nested templates that do nothing more than print out their name as well a couple of random numbers to ensure values aren't being cached so, while it is designed somewhat to replicate a site with many components, it's far from true to life. Saying this,  my tests have found this has given me a roughly 75% performance increase:
```text
Calculating -------------------------------------
              Before    100.263  (± 6.0%) i/s -      1.008k in  10.076792s
               After    174.497  (± 3.4%) i/s -      1.751k in  10.047389s
```

It's tricky to solve this elegantly so I'm very open to discussing alternative approaches.

One thing I considered was if there is support for adjusting these values at runtime. I couldn't think of any legitimate reason to do that but, if such a reason exists, I'm sure we could find a solution