### PR TITLE
Always cache config values

### DIFF
--- a/lib/dry/view.rb
+++ b/lib/dry/view.rb
@@ -34,6 +34,27 @@ module Dry
   #
   # @api public
   class View
+    class Config < Dry::Configurable::Config
+      # When the superclass returns a value, it only caches it to _values if it
+      # is considered "cloneable". The high frequency in which Dry::View calls
+      # this method, however, has considerable performance implications and, as
+      # such, as values are cached
+      #
+      # @see Dry::Configurable::Config#[]
+      #
+      # @param [String,Symbol] name
+      #
+      # @return Config value
+      def [](name)
+        name = name.to_sym
+        return _values[name] if _values.key?(name)
+
+        super
+        _values[name] = _settings[name].to_value unless _values.key?(name)
+        _values[name]
+      end
+    end
+
     # @api private
     DEFAULT_RENDERER_OPTIONS = {default_encoding: "utf-8"}.freeze
 
@@ -41,7 +62,7 @@ module Dry
 
     extend Dry::Core::Cache
 
-    extend Dry::Configurable
+    extend Dry::Configurable(config_class: Dry::View::Config)
 
     # @!group Configuration
 


### PR DESCRIPTION
When retrieving a value from Dry::Configurable::Config#[], the value is only cached to the `_values` array if it is considered "cloneable". Unfortunately, checking for cloneability is a costly exercise (at least when called at the frequency of Dry::View). 

The code states that this occurs as a means of helping understand when a setting has been mutated; however, I would like to suggest that the increase in performance that can be achieved in Dry::View rendering is more valuable. Saying this, I suggest modifying Dry::View rather than Dry::Configurable::Config because I doubt most uses have the same performance requirements.

In my benchmarks, I'm using a highly contrived template that loads 100 nested templates that do nothing more than print out their name as well a couple of random numbers to ensure values aren't being cached so, while it is designed somewhat to replicate a site with many components, it's far from true to life. Saying this, my tests have found this has given me a roughly 70% performance increase:
```
Calculating -------------------------------------
              Before    100.263  (±12.0%) i/s -      1.008k in  10.076792s
               After    169.272  (± 7.1%) i/s -      1.696k in  10.076434s
```
It's tricky to solve this elegantly so I'm very open to discussing alternative approaches.